### PR TITLE
Fix Cloud Run health check failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@eslint/js": "^9.26.0",
         "@redocly/cli": "^2.0.8",
         "@tsconfig/node22": "^22.0.1",
-        "@types/node": "^24.3.1",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/ui": "^3.2.4",
         "eslint-config-prettier": "^10.1.3",
@@ -31,7 +30,6 @@
         "prettier": "^3.5.3",
         "semantic-release": "^24.2.3",
         "tsx": "^4.19.4",
-        "typescript": "^5.8.3",
         "typescript-eslint": "^8.32.0",
         "vitest": "^3.1.3",
         "yaml": "^2.8.1"
@@ -2472,7 +2470,6 @@
       "version": "24.3.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.1.tgz",
       "integrity": "sha512-3vXmQDXy+woz+gnrTvuvNrPzekOi+Ds0ReMxw0LzBiK3a+1k0kQn9f2NWk+lgD4rJehFUmYy2gMhJ2ZI+7YP9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.10.0"
@@ -12987,7 +12984,6 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -13059,7 +13055,6 @@
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
       "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,12 +27,13 @@ if (process.env.NODE_ENV !== "test") {
   server.start({
     httpStream: {
       endpoint: config.endpoint as `/${string}`,
+      host: "0.0.0.0", // Bind to all network interfaces for Cloud Run accessibility
       port,
     },
     transportType: "httpStream",
   });
 
-  console.log(`MCP Server started on port ${port}`);
-  console.log(`Endpoint: http://localhost:${port}${config.endpoint}`);
-  console.log(`Health check: http://localhost:${port}/health`);
+  console.log(`MCP Server started on port ${port} (accessible on all interfaces)`);
+  console.log(`Endpoint: http://0.0.0.0:${port}${config.endpoint}`);
+  console.log(`Health check: http://0.0.0.0:${port}/health`);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,7 +33,9 @@ if (process.env.NODE_ENV !== "test") {
     transportType: "httpStream",
   });
 
-  console.log(`MCP Server started on port ${port} (accessible on all interfaces)`);
+  console.log(
+    `MCP Server started on port ${port} (accessible on all interfaces)`,
+  );
   console.log(`Endpoint: http://0.0.0.0:${port}${config.endpoint}`);
   console.log(`Health check: http://0.0.0.0:${port}/health`);
 }


### PR DESCRIPTION
## Summary
- Fixes STARTUP TCP probe failures in Google Cloud Run by configuring server to bind to 0.0.0.0
- Updates FastMCP httpStream configuration to bind to all network interfaces instead of localhost
- Updates console logs to reflect server accessibility on all interfaces

## Problem
The MCP server was binding to localhost (127.0.0.1) by default, making it unreachable by Cloud Run's health check probes, causing deployment failures.

## Solution
Added `host: "0.0.0.0"` configuration to the FastMCP httpStream setup to bind to all network interfaces, allowing Cloud Run to successfully perform health checks on the `/health` endpoint.

## Test plan
- [x] Verify health endpoint responds correctly locally
- [x] Confirm FastMCP accepts host configuration
- [ ] Deploy to Cloud Run and verify health checks pass
- [ ] Confirm MCP functionality still works after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)