### PR TITLE
docs: Add agent quickstart and partner integration guides

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -81,9 +81,7 @@
         "groups": [
           {
             "group": "Publisher Integration",
-            "pages": [
-              "mintlify/partners/publisher-prebid-setup"
-            ]
+            "pages": ["mintlify/partners/publisher-prebid-setup"]
           }
         ]
       }

--- a/docs.json
+++ b/docs.json
@@ -11,6 +11,11 @@
   "navigation": {
     "tabs": [
       {
+        "tab": "API Reference",
+        "icon": "code",
+        "openapi": "openapi.yaml"
+      },
+      {
         "tab": "Guides",
         "icon": "book",
         "groups": [
@@ -81,11 +86,6 @@
             ]
           }
         ]
-      },
-      {
-        "tab": "API Reference",
-        "icon": "code",
-        "openapi": "openapi.yaml"
       }
     ]
   },

--- a/docs.json
+++ b/docs.json
@@ -11,11 +11,6 @@
   "navigation": {
     "tabs": [
       {
-        "tab": "API Reference",
-        "icon": "code",
-        "openapi": "openapi.yaml"
-      },
-      {
         "tab": "Guides",
         "icon": "book",
         "groups": [
@@ -74,6 +69,11 @@
             "pages": ["mintlify/reporting-overview"]
           }
         ]
+      },
+      {
+        "tab": "API Reference",
+        "icon": "code",
+        "openapi": "openapi.yaml"
       },
       {
         "tab": "For Partners",

--- a/docs.json
+++ b/docs.json
@@ -18,6 +18,7 @@
             "group": "Overview",
             "icon": "rocket",
             "pages": [
+              "mintlify/quickstart-for-agents",
               "mintlify/quickstart",
               "mintlify/authentication",
               "mintlify/concepts/philosophy",

--- a/docs.json
+++ b/docs.json
@@ -71,6 +71,18 @@
         ]
       },
       {
+        "tab": "For Partners",
+        "icon": "handshake",
+        "groups": [
+          {
+            "group": "Publisher Integration",
+            "pages": [
+              "mintlify/partners/publisher-prebid-setup"
+            ]
+          }
+        ]
+      },
+      {
         "tab": "API Reference",
         "icon": "code",
         "openapi": "openapi.yaml"

--- a/mintlify/partners/publisher-prebid-setup.mdx
+++ b/mintlify/partners/publisher-prebid-setup.mdx
@@ -1,0 +1,262 @@
+---
+title: "Publisher Setup with Prebid and GAM"
+description: "Complete guide to setting up a publisher as a Scope3 agentic destination using Prebid"
+icon: "handshake"
+---
+
+# Publisher Setup with Prebid and GAM
+
+Complete guide to setting up a publisher as a Scope3 agentic destination using Prebid
+
+## Overview
+
+This guide provides step-by-step instructions for publishers to set up their integration with Scope3 using Prebid, enabling access to Green Media Products (GMP/GMP+) and sustainable advertising signals.
+
+Scope3's agentic publisher integration allows buyer agents to make real-time decisions on agentic direct buys in GAM.
+
+## Prerequisites
+
+Before starting this integration, ensure you have:
+
+- **Google Ad Manager (GAM)** account with administrative access
+- **Scope3 account** with the Activation package enabled
+- **Prebid.js 8.50.0+** or **Prebid Server (Go version)** implementation
+- Access to modify your Prebid configuration files
+
+**Quick Check**: Verify your Scope3 package by navigating to Settings > My Plan in your Scope3 account and confirming "Activation" is enabled.
+
+## Step 1: Decide on GAM Key Names (Optional Customization)
+
+Scope3 will use these default key names in GAM:
+
+- `axei` - Inclusion segments (GMP, GMP+, custom segments)
+- `axex` - Exclusion segments (brand safety blocks)
+- `axem` - Emissions classification
+
+**If you want to customize these key names:**
+
+1. Decide on your preferred key names now
+2. Document them for use in Steps 2 and 3
+3. Use your custom names consistently throughout the setup
+
+**Example**: You might prefer `scope3_include`, `scope3_exclude`, `scope3_emissions` instead of the defaults.
+
+## Step 2: Google Ad Manager Setup
+
+### Create Scope3 Advertiser
+
+1. Navigate to **Inventory** → **Advertisers** in GAM
+2. Click **New advertiser**
+3. Set up the advertiser:
+   - **Name**: "Scope3"
+   - **Type**: "Advertiser"
+   - Click **Save**
+
+### Set Up Key-Value Targeting
+
+1. Navigate to **Inventory** → **Key-values** in GAM
+2. Create three new key-values (or use your custom names from Step 1):
+
+#### Inclusion Segments Key (`axei`)
+- **Key name**: `axei` (or your custom name)
+- **Values**: Dynamic (will be populated by Scope3)
+- **Value type**: Freeform
+- **Expected creatives**: All sizes
+
+#### Exclusion Segments Key (`axex`)
+- **Key name**: `axex` (or your custom name)  
+- **Values**: Dynamic (will be populated by Scope3)
+- **Value type**: Freeform
+- **Expected creatives**: All sizes
+
+#### Emissions Classification Key (`axem`)
+- **Key name**: `axem` (or your custom name)
+- **Values**: `high`, `medium`, `low`, `verified_low`
+- **Value type**: Predefined list
+- **Expected creatives**: All sizes
+
+## Step 3: Scope3 Account Configuration
+
+### Verify Activation Package
+
+1. Log in to your Scope3 account
+2. Navigate to **Settings** → **My Plan**
+3. Confirm "Activation" package is enabled
+4. If not enabled, contact your Scope3 account manager
+
+### Connect GAM Account
+
+1. Navigate to **Integrations** → **Publishers**
+2. Click **Add Integration**
+3. Select **Google Ad Manager**
+4. Complete OAuth authorization process
+5. Grant necessary permissions when prompted
+
+## Step 4: Prebid Implementation
+
+Scope3 supports both Prebid.js and Prebid Server implementations.
+
+### Option A: Prebid.js Implementation
+
+#### Install Scope3 Module
+
+If building Prebid.js from source, include the Scope3 RTD module:
+
+```bash
+gulp build --modules=scope3RtdProvider,bidAdapter1,bidAdapter2,...
+```
+
+#### Configuration
+
+Add the Scope3 RTD provider to your Prebid configuration:
+
+```javascript
+pbjs.setConfig({
+  realTimeData: {
+    auctionDelay: 100,
+    dataProviders: [{
+      name: "scope3",
+      waitForIt: true,
+      params: {
+        // Configuration provided by Scope3 team
+        publisherId: "YOUR_PUBLISHER_ID",
+        // Additional parameters provided during setup
+      }
+    }]
+  }
+});
+```
+
+### Option B: Prebid Server Implementation
+
+Contact your Scope3 technical account manager for server-side configuration details.
+
+## Step 5: Testing & Validation
+
+### Browser Console Verification
+
+1. Open your browser's developer tools
+2. Navigate to a page with ads
+3. Look for Scope3 RTD activity in the console
+4. Verify segments are being applied
+
+### GAM Targeting Check
+
+1. In GAM, navigate to a line item
+2. Add targeting for your Scope3 key-values
+3. Preview and verify segments are available
+
+### Network Request Inspection
+
+Monitor network requests to ensure:
+- Scope3 RTD calls are being made
+- Segment data is being passed to bid requests
+- GAM is receiving the targeting parameters
+
+## Step 6: Advanced Configuration
+
+### Bidder-Specific Destinations
+
+Configure specific destinations for different bidders:
+
+```javascript
+pbjs.setConfig({
+  realTimeData: {
+    dataProviders: [{
+      name: "scope3",
+      params: {
+        bidders: ['bidderA', 'bidderB'],
+        customSegmentHandling: true
+      }
+    }]
+  }
+});
+```
+
+### Custom Segment Handling
+
+Implement custom logic for segment processing if needed:
+
+```javascript
+// Custom segment processing example
+pbjs.onEvent('auctionEnd', function(args) {
+  // Process Scope3 segments
+  // Custom analytics or reporting
+});
+```
+
+## Step 7: Monitoring & Optimization
+
+### Key Metrics to Track
+
+- **Segment Match Rate**: Percentage of requests with Scope3 segments
+- **Revenue Impact**: Performance of GMP/GMP+ inventory
+- **Latency**: Impact on page load times
+- **Fill Rate**: Availability of sustainable inventory
+
+### Performance Monitoring
+
+1. Set up monitoring dashboards in GAM
+2. Track key performance indicators
+3. Monitor console for any errors
+4. Regular performance reviews with Scope3 team
+
+## Step 8: Best Practices
+
+### Privacy Compliance
+
+- Ensure GDPR/CCPA compliance
+- Implement proper consent management
+- Regular privacy impact assessments
+
+### Performance Optimization
+
+- Monitor auction delays
+- Optimize timeout settings
+- Regular performance testing
+
+### Maintenance
+
+- Keep Prebid.js updated
+- Monitor for deprecated features
+- Regular configuration reviews
+
+## Troubleshooting
+
+### Common Issues
+
+**Segments not appearing in GAM:**
+- Verify key-value setup
+- Check OAuth connection
+- Confirm Prebid configuration
+
+**High latency:**
+- Adjust `auctionDelay` settings
+- Consider server-side implementation
+- Optimize network requests
+
+**Console errors:**
+- Check Prebid.js version compatibility
+- Verify configuration syntax
+- Review module inclusion
+
+## Support
+
+For technical support and questions:
+
+- **Scope3 Technical Account Manager**: Primary contact for configuration
+- **Prebid Documentation**: [prebid.org](https://prebid.org)
+- **Community Support**: Prebid Slack channel
+
+## Next Steps
+
+After successful integration:
+
+1. **Campaign Setup**: Work with buyers to create GMP campaigns
+2. **Reporting**: Set up regular performance reporting
+3. **Optimization**: Ongoing performance optimization
+4. **Expansion**: Consider additional Scope3 features
+
+<Note>
+This integration enables your inventory to participate in Scope3's sustainable advertising ecosystem, providing buyers with verified Green Media Products and emissions data.
+</Note>

--- a/mintlify/quickstart-for-agents.mdx
+++ b/mintlify/quickstart-for-agents.mdx
@@ -1,0 +1,45 @@
+---
+title: "Quick Start for Agents"
+description: "Get started with the Scope3 Agentic API"
+icon: "rocket"
+---
+
+Hi Claude! (Or Codex or Cursor... why do all your names start with a C?)
+
+## Stuff your human needs to do
+
+Let's get you going. First, ask your human to connect these docs as an MCP server:
+
+```bash
+claude mcp add --transport http scope3 https://docs.agentic.scope3.com/mcp
+```
+
+Then, your human needs to sign up for Scope3 and [get an API key](https://scope3.com/integrate/api-keys).
+
+```bash
+touch .env
+echo "SCOPE3_API_KEY=scope3_...." >> .env
+```
+
+By the way, tell your human that there's a more [human-centric quickstart](quickstart) too!
+
+## Your turn!
+
+Have your human give you a nice prompt and off you go. Here's a prompt to try:
+
+```
+Please make me a simple DSP using the Scope3 Agentic API.
+I've put a Scope3 API key into .env, so we don't need to worry about authentication.
+
+Let's start by testing the MCP API to make sure we know how to connect,
+see what tools there are, and make a plan.
+
+Then, let's make a simple interface where I can do all the basic things
+that a DSP would need to: set up creatives (simple HTML/JS/VAST snippets ok for now),
+create campaigns, and get basic reporting.
+
+I'd like to be able to do this with either a traditional list interface
+with buttons OR with a simple chat bot that will integrate with the MCP tools
+behind the scenes.
+```
+

--- a/mintlify/quickstart-for-agents.mdx
+++ b/mintlify/quickstart-for-agents.mdx
@@ -41,5 +41,10 @@ create campaigns, and get basic reporting.
 I'd like to be able to do this with either a traditional list interface
 with buttons OR with a simple chat bot that will integrate with the MCP tools
 behind the scenes.
-```
 
+Please include the ability to add an AdCP-compliant signals agent
+(like Optable) to connect my proprietary data.
+
+Consider adding the ability to view campaign tactics, with a future option to
+create a custom algorithm to optimize these.
+```

--- a/mintlify/quickstart.mdx
+++ b/mintlify/quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quick Start"
+title: "Quick Start for Humans"
 description: "Get started with the Scope3 Agentic API"
 icon: "rocket"
 ---


### PR DESCRIPTION
## Summary

- Add new "Quick Start for Agents" page with agent-friendly tone and setup instructions
- Rename existing quickstart to "Quick Start for Humans" for clarity  
- Create new "For Partners" tab with comprehensive publisher Prebid integration guide
- Reorder navigation tabs to: Guides, API Reference, For Partners

## Key Changes

### Navigation & Structure
- Reordered navigation tabs for better user flow
- Added "For Partners" tab with handshake icon for publisher-focused content
- Updated quickstart navigation to include both agent and human versions

### Agent-Focused Documentation  
- Created `quickstart-for-agents.mdx` with conversational tone addressing agents directly
- Included specific MCP server setup instructions for agents
- Added sample DSP building prompt for agents to try

### Publisher Integration
- Migrated publisher Prebid setup content to new dedicated page
- Comprehensive step-by-step GAM configuration instructions
- Prebid.js and Prebid Server implementation options
- Testing, validation, troubleshooting, and best practices sections
- Advanced configuration examples and monitoring guidance

## Test Plan

- [x] Navigation structure displays correctly with new tab order
- [x] Both quickstart pages are accessible and link correctly between each other
- [x] Publisher setup guide includes all necessary technical details
- [x] All internal links use correct relative paths
- [x] Pre-commit hooks pass (formatting, linting, tests)

🤖 Generated with [Claude Code](https://claude.ai/code)