### PR TITLE
docs: Partner authentication, region updates, and signals agent improvements

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -61,7 +61,7 @@
             "pages": [
               "mintlify/integrations/webhooks",
               "mintlify/integrations/creative-agents",
-              "mintlify/integrations/custom-signals-platform"
+              "mintlify/integrations/signals-agents"
             ]
           },
           {
@@ -82,6 +82,15 @@
           {
             "group": "Publisher Integration",
             "pages": ["mintlify/partners/publisher-prebid-setup"]
+          },
+          {
+            "group": "Signals Management", 
+            "icon": "database",
+            "pages": [
+              "mintlify/partners/authentication",
+              "mintlify/partners/segment-management",
+              "mintlify/partners/data-attachment"
+            ]
           }
         ]
       }

--- a/docs.json
+++ b/docs.json
@@ -80,6 +80,12 @@
         "icon": "handshake",
         "groups": [
           {
+            "group": "Getting Started",
+            "pages": [
+              "mintlify/partners/authentication"
+            ]
+          },
+          {
             "group": "Publisher Integration",
             "pages": [
               "mintlify/partners/publisher-setup",
@@ -91,7 +97,6 @@
             "group": "Signals Management", 
             "icon": "database",
             "pages": [
-              "mintlify/partners/authentication",
               "mintlify/partners/segment-management",
               "mintlify/partners/data-attachment"
             ]

--- a/docs.json
+++ b/docs.json
@@ -81,9 +81,7 @@
         "groups": [
           {
             "group": "Getting Started",
-            "pages": [
-              "mintlify/partners/authentication"
-            ]
+            "pages": ["mintlify/partners/authentication"]
           },
           {
             "group": "Publisher Integration",
@@ -94,7 +92,7 @@
             ]
           },
           {
-            "group": "Signals Management", 
+            "group": "Signals Management",
             "icon": "database",
             "pages": [
               "mintlify/partners/segment-management",

--- a/mintlify/concepts.mdx
+++ b/mintlify/concepts.mdx
@@ -250,7 +250,7 @@ The API supports two distinct reporting approaches:
   </Tab>
   <Tab title="Enterprise Systems">
     **Structured Data Exports**
-    - JSON/CSV/Parquet formats
+    - JSON/CSV formats
     - Flexible grouping and aggregation
     - BI system integration
     - Custom date ranges and filters

--- a/mintlify/integrations/custom-signals-platform.mdx
+++ b/mintlify/integrations/custom-signals-platform.mdx
@@ -76,8 +76,8 @@ await createCustomSignal({
   key: "maid",
   description: "Sports fans identified via mobile advertising IDs",
   clusters: [
-    {"region": "us-east-1"},
-    {"region": "eu-west-1", "gdpr": true}
+    {"region": "americas"},
+    {"region": "eu"}
   ]
 });
 ```
@@ -406,7 +406,7 @@ The Campaign API MCP server provides dedicated tools for managing custom signal 
       name: "Updated Signal Name",
       description: "Updated description",
       clusters: [
-        {"region": "eu-west-1", "gdpr": true}
+        {"region": "eu"}
       ]
     });
     ```
@@ -459,8 +459,8 @@ Invalid key types will be rejected with helpful error messages listing valid opt
 ```json
 {
   "clusters": [
-    {"region": "eu-west-1", "gdpr": true},
-    {"region": "eu-central-1", "gdpr": true}
+    {"region": "eu"},
+    {"region": "eu"}
   ]
 }
 ```

--- a/mintlify/integrations/signals-agents.mdx
+++ b/mintlify/integrations/signals-agents.mdx
@@ -1,0 +1,147 @@
+---
+title: "Signals Agents"
+description: "How we use signals agents for campaign optimization"
+icon: "robot"
+---
+
+## Overview
+
+Signals agents provide audience segments and targeting recommendations during campaign setup. When you create a campaign, we query registered signals agents to get relevant segments for your targeting criteria.
+
+## How It Works
+
+```mermaid
+graph LR
+
+ A[Campaign Creation] -->|Query with prompt| B(Signals Agent)
+
+     A[Campaign Creation] -->|Query with prompt| E(Data marketplace)
+     E-->|Recommended segments|A
+    B --> |Segments|A
+    A --> Q[Campaign engine chooses best segments]
+    
+    B --> |Query with prompt|C(Internal data catalog)
+    C --> |Custom and standard segments|B
+
+
+```
+
+### The Process
+
+1. **Campaign Setup**: You create a campaign with targeting criteria
+2. **Agent Query**: We call your registered signals agent with campaign context
+3. **Segment Response**: Agent returns relevant segments from your data
+4. **Campaign Optimization**: Segments are added to campaign targeting
+
+## Connecting Signals Agents
+
+Scope3 works with various data platforms that provide signals agents:
+- [Optable](https://www.optable.co)
+
+For LiveRamp customers, we provide an open source signals agent to make data available to the platform. Please contact us for more information!
+
+## Managing Signals Agents
+
+### Register Agent
+
+**MCP Tool**: `signals-agent/register`
+
+Register a new signals agent for your seat:
+
+```json
+{
+  "tool": "signals-agent/register",
+  "parameters": {
+    "name": "My Data Agent",
+    "endpointUrl": "https://my-agent.example.com/adcp",
+    "description": "Custom audience targeting using proprietary data"
+  }
+}
+```
+
+**Required Parameters:**
+- `name` - Human-readable agent name
+- `endpointUrl` - ADCP-compliant endpoint URL
+- `description` - Agent description and capabilities
+
+### List Agents
+
+**MCP Tool**: `signals-agent/list`
+
+View all registered signals agents:
+
+```json
+{
+  "tool": "signals-agent/list",
+  "parameters": {}
+}
+```
+
+Returns agent details including status, registration date, and activity metrics.
+
+### Get Agent Details
+
+**MCP Tool**: `signals-agent/get`
+
+Get detailed information about a specific agent:
+
+```json
+{
+  "tool": "signals-agent/get", 
+  "parameters": {
+    "agentId": "agent_456"
+  }
+}
+```
+
+Returns complete agent configuration including:
+- Agent ID, name, and description
+- Endpoint URL and status
+- Registration date and last activity
+- Performance metrics and query counts
+- Access permissions and authentication details
+
+### Update Agent
+
+**MCP Tool**: `signals-agent/update`
+
+Modify agent configuration:
+
+```json
+{
+  "tool": "signals-agent/update",
+  "parameters": {
+    "agentId": "agent_456",
+    "name": "Updated Agent Name",
+    "description": "Updated description"
+  }
+}
+```
+
+### Unregister Agent
+
+**MCP Tool**: `signals-agent/unregister`
+
+Remove an agent and revoke its access:
+
+```json
+{
+  "tool": "signals-agent/unregister",
+  "parameters": {
+    "agentId": "agent_456"
+  }
+}
+```
+
+<Warning>
+Unregistering an agent will revoke its API access and stop it from being queried during campaign creation.
+</Warning>
+
+## Building Signals Agents
+
+For technical details on building signals agents, see the [ADCP documentation](https://adcontextprotocol.org/docs/signals/overview).
+
+Once your agent is built and registered, you'll need to:
+
+- [Create and manage segments](/partners/segment-management) via our APIs
+- [Attach data to segments](/partners/data-attachment) through real-time APIs or CSV uploads

--- a/mintlify/object-guides/campaign.mdx
+++ b/mintlify/object-guides/campaign.mdx
@@ -484,12 +484,12 @@ const exportData = await exportCampaignData({
   },
   datasets: ["delivery", "events", "tactics"],
   groupBy: ["date", "campaign", "tactic", "signal"],
-  format: "parquet", // Optimized for analytics
+  format: "csv", // Optimized for analytics
   compression: "gzip"
 });
 
 // Use exported data in your BI pipeline
-// Supports: JSON, CSV, Parquet formats
+// Supports: JSON, CSV formats
 // Integrates with: Snowflake, BigQuery, Databricks, etc.
 ```
 

--- a/mintlify/object-guides/signal.mdx
+++ b/mintlify/object-guides/signal.mdx
@@ -35,6 +35,22 @@ Third-party signals are **coming soon**. Contact support@scope3.com for early ac
 
 Upload and manage your first-party data through the [Custom Signals Platform](../integrations/custom-signals-platform).
 
+### 3. Agent-Managed Signals
+
+**Intelligent data retrieval** - powered by external signals agents:
+
+Signals agents act as a RAG (Retrieval-Augmented Generation) process, intelligently surfacing the most relevant segments from proprietary data catalogs:
+
+- **LiveRamp Integration**: Access your LiveRamp audience segments with RampID resolution
+- **Optable Integration**: Privacy-first data clean room segments (coming soon)  
+- **Custom Agents**: Your own algorithms and data sources via ADCP protocol
+
+**Ownership Model**: Agents manage segments they create, with complete audit trails of all actions.
+
+**Multi-Seat Support**: Partners can manage segments across multiple brand agent seats with proper access controls.
+
+Learn more about [Signals Agents](../integrations/signals/overview) and building [Custom Agents](../integrations/signals/custom).
+
 ## How Signal RAG Works
 
 **Signal Retrieval-Augmented Generation (RAG)** is how the platform combines multiple signal types to create optimized targeting tactics:
@@ -81,6 +97,37 @@ const campaign = await createCampaign({
 // - Built-in: premium_inventory, high_completion_rate targeting
 // - Creates optimized tactics combining these signals
 ```
+
+### Managing Signals Across Seats
+
+**For Partners & Multi-Seat Users**: Signals can be filtered and managed across multiple brand agent seats:
+
+```javascript
+// Discover which seats you can access
+await getPartnerSeats();
+
+// List all signals across accessible seats 
+await listSignals();
+// Each signal includes seat information (seatId, seatName)
+
+// Filter signals by specific seat
+await listSignals({ 
+  seatId: "seat_abc123" 
+});
+
+// Combine seat and regional filtering
+await listSignals({ 
+  seatId: "seat_abc123",
+  region: "americas" 
+});
+```
+
+**Seat Information**: When listing signals, each signal shows:
+- **Seat ID**: Brand agent identifier that owns the signal
+- **Seat Name**: Human-readable brand agent name  
+- **Standard Metadata**: Signal name, description, key type, regions, etc.
+
+This enables partners to understand signal deployment across their client accounts and manage targeting at the seat level.
 
 ### Performance Analysis
 

--- a/mintlify/partners/authentication.mdx
+++ b/mintlify/partners/authentication.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Partner Authentication"
-description: "Authentication setup for partners managing multiple seats"
+description: "Authentication setup for partners and agent integrations"
 icon: "key"
 ---
 
 ## Overview
 
-Partners managing multiple brand agent seats require authentication to access resources across seats. This guide covers setup and seat access discovery.
+Partners and agent integrations require authentication to access platform resources. This guide covers API key setup and seat access discovery for multi-seat management.
 
 ## API Key Setup
 
@@ -18,7 +18,7 @@ Authorization: Bearer YOUR_API_KEY
 
 <Warning>
 **API Key Security:**
-- Contact api-support@scope3.com to obtain your API key
+- Get your Scope3 API key: [Get one here](https://scope3.com/integrate/api-keys)
 - Use HTTPS only - never send keys over HTTP
 - Store keys securely and rotate regularly
 - Each API key provides access to specific seats based on your partner configuration

--- a/mintlify/partners/authentication.mdx
+++ b/mintlify/partners/authentication.mdx
@@ -1,0 +1,153 @@
+---
+title: "Partner Authentication"
+description: "Authentication setup for partners managing multiple seats"
+icon: "key"
+---
+
+## Overview
+
+Partners managing multiple brand agent seats require authentication to access resources across seats. This guide covers setup and seat access discovery.
+
+## API Key Setup
+
+All API requests require an API key in the `Authorization` header:
+
+```bash
+Authorization: Bearer YOUR_API_KEY
+```
+
+<Warning>
+**API Key Security:**
+- Contact api-support@scope3.com to obtain your API key
+- Use HTTPS only - never send keys over HTTP
+- Store keys securely and rotate regularly
+- Each API key provides access to specific seats based on your partner configuration
+</Warning>
+
+## Discovering Accessible Seats
+
+### Check Seat Access
+
+**MCP Tool**: `signals/get-partner-seats`
+
+Use this tool to discover which brand agent seats your API key can access:
+
+```json
+{
+  "tool": "signals/get-partner-seats",
+  "parameters": {}
+}
+```
+
+**Response includes:**
+- Seat ID and display name
+- Brand agent information
+- Access permissions and scope
+- Last activity date
+
+### Using Seat Information
+
+Once you know which seats you can access, you can:
+
+**Filter operations by seat:**
+```json
+{
+  "tool": "signals/list",
+  "parameters": {
+    "seatId": "seat_abc123"
+  }
+}
+```
+
+**Access seat-specific resources:**
+- Signals and segments
+- Campaign data
+- Performance metrics
+- Configuration settings
+
+## Authentication Scopes
+
+Partner API keys provide different access levels:
+
+### Read Access
+- List accessible seats
+- View segments and signals
+- Read campaign performance data
+- Access reporting APIs
+
+### Write Access  
+- Create and update segments
+- Attach data to segments
+- Register signals agents
+- Modify campaign configurations
+
+### Administrative Access
+- Manage API key permissions
+- Configure seat access controls
+- Set up webhook endpoints
+- Access audit logs
+
+## Multi-Seat Operations
+
+When working across multiple seats, operations automatically scope to your accessible seats:
+
+**List all segments across seats:**
+```json
+{
+  "tool": "signals/list",
+  "parameters": {}
+}
+```
+
+**Results include seat information:**
+- `seatId` - Unique seat identifier
+- `seatName` - Human-readable seat name  
+- Standard resource metadata
+
+This enables you to understand which seat owns each resource and manage targeting at the seat level.
+
+## Error Handling
+
+**Common authentication errors:**
+
+### Invalid API Key
+```json
+{
+  "error": "unauthorized",
+  "message": "Invalid or expired API key"
+}
+```
+
+### Insufficient Permissions
+```json
+{
+  "error": "forbidden", 
+  "message": "API key does not have access to requested seat"
+}
+```
+
+### Seat Not Found
+```json
+{
+  "error": "seat_not_found",
+  "message": "Seat 'seat_xyz' not found or not accessible"
+}
+```
+
+## Next Steps
+
+After authentication setup:
+
+<CardGroup cols={2}>
+  <Card title="Segment Management" href="/partners/segment-management" icon="list">
+    **Manage Segments**
+    
+    Create, list, and update audience segments across your accessible seats.
+  </Card>
+  
+  <Card title="Data Attachment" href="/partners/data-attachment" icon="database">
+    **Attach Data**
+    
+    Upload audience data using real-time APIs or CSV file uploads.
+  </Card>
+</CardGroup>

--- a/mintlify/partners/data-attachment.mdx
+++ b/mintlify/partners/data-attachment.mdx
@@ -1,0 +1,156 @@
+---
+title: "Data Attachment"
+description: "Attach audience data to segments via real-time API or CSV upload"
+icon: "upload"
+---
+
+## Overview
+
+After creating segments, populate them with audience data using two methods:
+
+1. **Real-time API** - Live data streaming with immediate updates
+2. **CSV Upload** - Batch processing for larger datasets
+
+Both methods use the same command syntax and operations.
+
+## Data Operations
+
+All data operations use these commands:
+
+- **ADD** - Add segments to a key
+- **REM** - Remove specific segments from a key  
+- **DEL** - Delete all segments from a key
+- **SET** - Overwrite all segments for a key (replaces existing)
+
+## Method 1: Real-time API
+
+### API Endpoint
+
+```
+POST https://api.agentic.scope3.com/rest/v1/signal/attach/[seat]/[keydef]
+```
+
+Where:
+- `[seat]` - Brand agent seat ID  
+- `[keydef]` - Key definition, either simple (`maid`) or composite (`domain,daypart`)
+
+<Info>
+The keydef must match what the segment was configured with during creation.
+</Info>
+
+### Request Format
+
+Send operations in the request body, one per line:
+
+```
+ADD abcd-2832-abcd-238-abcd segment1
+REM aefa-9281-aefa-821-aefa segment2
+DEL aaab-2712-aaab-132-aaab
+SET d82a-1811-d82a-921-d82a segment1 segment3
+```
+
+### Example Requests
+
+**Single Key Type (MAID)**:
+```bash
+curl -X POST https://api.agentic.scope3.com/rest/v1/signal/attach/seat_123/maid \
+  -H "Authorization: Bearer $SCOPE3_API_KEY" \
+  -d "ADD d82a-1811-d82a-921-d82a premium_customers high_value"
+```
+
+**Composite Key Type**:
+```bash  
+curl -X POST https://api.agentic.scope3.com/rest/v1/signal/attach/seat_123/domain,daypart \
+  -H "Authorization: Bearer $SCOPE3_API_KEY" \
+  -d "SET example.com,morning premium_content morning_audience"
+```
+
+## Method 2: CSV Upload
+
+### CSV File Format
+
+CSV files use the same operation syntax:
+
+```csv
+operation,key,segments
+ADD,abcd-2832-abcd-238-abcd,segment1 segment2
+REM,aefa-9281-aefa-821-aefa,segment2
+DEL,aaab-2712-aaab-132-aaab,
+SET,d82a-1811-d82a-921-d82a,segment1 segment3
+```
+
+### Alternative: Action in Filename
+
+If CSV lacks the operation column, specify action in filename:
+
+**Filenames**:
+- `audience_add_20241201.csv` - ADD operation
+- `audience_rem_20241201.csv` - REM operation  
+- `audience_del_20241201.csv` - DEL operation
+- `audience_set_20241201.csv` - SET operation
+
+**File content** (without operation column):
+```csv
+key,segments
+abcd-2832-abcd-238-abcd,segment1 segment2
+aefa-9281-aefa-821-aefa,segment2
+```
+
+### Upload Process
+
+For CSV file uploads, follow the Scope3 API documentation:
+
+**[Scope3 File Upload Guide](https://docs.scope3.com/docs/integrate-ui-setup#/2-file-upload)**
+
+## Data Retrieval
+
+Check what segments are assigned to a key:
+
+```
+GET https://api.scope3.com/audience/[provider]/maid/d82a-1811-d82a-921-d82a
+```
+
+**Response**:
+```
+TTL: 18321
+segment1
+segment3
+```
+
+<Info>
+All keys have a **30-day TTL**. Keys not accessed within 30 days are automatically removed.
+</Info>
+
+## Best Practices
+
+### Real-time API
+- Batch multiple operations in a single request when possible
+- Use SET operations sparingly - they replace all existing segments
+- Monitor API response codes for processing status
+
+### CSV Upload
+- Use clear filenames indicating operation type and date
+- Include header rows in CSV files
+- Split large datasets into manageable batches
+- Use gzip compression for large files (.csv.gz)
+
+### Data Management
+- Regular cleanup using DEL operations for inactive keys
+- Monitor the 30-day TTL for key retention
+- Track segment record counts for billing purposes
+
+## Error Handling
+
+Common scenarios:
+
+- **Invalid keydef**: Ensure keydef matches segment configuration
+- **Seat not found**: Verify seat ID exists and is accessible
+- **Segment not found**: Check segment exists for the specified seat
+- **Format errors**: Validate operation syntax and CSV structure
+
+## Next Steps
+
+After populating segments:
+- Data is processed and available for targeting within 15 minutes
+- Monitor segment record counts via `signals/list` 
+- Segments become available in campaign targeting options

--- a/mintlify/partners/segment-management.mdx
+++ b/mintlify/partners/segment-management.mdx
@@ -1,0 +1,229 @@
+---
+title: "Segment Management"
+description: "Create, list, and update audience segments using the Scope3 API"
+icon: "list"
+---
+
+## Overview
+
+Segments are audience definitions that can be referenced in campaign targeting. This guide covers the core segment management operations using our MCP tools.
+
+## Authentication
+
+All segment operations require API authentication. See our [Partner Authentication Guide](/partners/authentication) for setup instructions including seat access discovery.
+
+## List Segments
+
+**MCP Tool**: `signals/list`
+
+View all segments or filter by specific criteria:
+
+```json
+{
+  "tool": "signals/list",
+  "parameters": {}
+}
+
+// Filter by region
+{
+  "tool": "signals/list",
+  "parameters": {
+    "region": "americas"
+  }
+}
+
+// Filter by channel
+{
+  "tool": "signals/list",
+  "parameters": {
+    "channel": "web"
+  }
+}
+
+// Filter by specific seat (for partners managing multiple accounts)
+{
+  "tool": "signals/list",
+  "parameters": {
+    "seatId": "seat_abc123"
+  }
+}
+```
+
+**Response includes:**
+- Segment ID and name
+- Description and key type
+- Regional clusters and GDPR compliance
+- Seat information (for multi-seat access)
+- **Record count** for each segment/seat (billable data point)
+
+## Create Segment
+
+**MCP Tool**: `signals/create`
+
+Create a new audience segment:
+
+```json
+{
+  "tool": "signals/create",
+  "parameters": {
+    "name": "High Value Customers",
+    "description": "Customers with >$1000 lifetime value",
+    "keyType": "maid",
+    "clusters": [
+      {"region": "americas", "channel": "web"},
+      {"region": "eu", "channel": "web"}
+    ]
+  }
+}
+```
+
+**Required Parameters:**
+- `name` - Human-readable segment name
+- `description` - Segment definition and criteria
+- `keyType` - Identifier type (see Key Types section below)
+- `clusters` - Regional deployment configuration
+
+## Key Types
+
+Segments can be defined using various targeting keys:
+
+### Core Targeting Keys
+- Basic targeting parameters
+
+### Temporal Keys
+- `hour` - Hour-based targeting
+- `half_hour` - Half-hour time segments
+- `day` - Day-based targeting
+
+### Content & Media Keys
+- `property` - Media property targeting
+- `publisher` - Publisher-specific targeting
+- `seller` - Seller identification
+- `content_channel` - Content channel classification
+- `content_network` - Network-based content targeting
+- `content_show` - Specific show targeting
+- `content_language` - Content language targeting
+- `content_livestream` - Live streaming content
+- `content_genre` - Content genre classification
+- `content_rating` - Content rating targeting
+- `content_series` - Series-based targeting
+- `content_length_min` - Minimum content length
+- `content_length_max` - Maximum content length
+
+### Geographic Keys
+- `dma` - Designated Market Area
+- `city` - City-level targeting
+- `country` - Country-level targeting
+- `region` - Regional targeting
+- `postal_code` - Postal/ZIP code targeting
+
+### Provider & Device Keys
+- `provider.category` - Provider category classifications
+- `provider.segment` - Provider-specific segment identifiers
+- `device_type` - Device type targeting
+- `device_model` - Specific device model
+- `device_make` - Device manufacturer
+- `operating_system` - OS-based targeting
+
+### Performance Metrics (Decile-based)
+- `co2e_decile` - Carbon footprint performance deciles
+- `viewability_decile` - Viewability performance deciles
+- `attention_potential_decile` - Attention potential deciles
+- `completion_rate_decile` - Completion rate performance deciles
+
+### Audience Keys
+- `maid` - Mobile Advertising ID
+- `liveramp` - LiveRamp authenticated identifiers
+- `lat_lng_radius` - Geographic coordinates with radius targeting
+- `id5` - ID5 universal identifiers
+- `coreid` - CoreID identifiers
+- `yahoo_connect` - Yahoo Connect IDs
+
+<Note>
+Composite keys may have additional fees and provide more granular audience segmentation capabilities.
+</Note>
+
+## Get Segment Details
+
+**MCP Tool**: `signals/get`
+
+Retrieve specific segment information:
+
+```json
+{
+  "tool": "signals/get",
+  "parameters": {
+    "signalId": "signal_123"
+  }
+}
+```
+
+Returns complete segment configuration including metadata, cluster settings, and record counts.
+
+## Update Segment
+
+**MCP Tool**: `signals/update`
+
+Modify existing segment properties:
+
+```json
+{
+  "tool": "signals/update",
+  "parameters": {
+    "signalId": "signal_123",
+    "name": "Premium Customers",
+    "description": "Updated criteria for premium tier",
+    "clusters": [
+      {"region": "americas", "channel": "web"},
+      {"region": "apac-ex-china", "channel": "mobile"}
+    ]
+  }
+}
+```
+
+## Delete Segment
+
+**MCP Tool**: `signals/delete`
+
+Remove a segment (this will also remove associated data):
+
+```json
+{
+  "tool": "signals/delete",
+  "parameters": {
+    "signalId": "signal_123"
+  }
+}
+```
+
+<Warning>
+Deleting a segment permanently removes all associated audience data. This action cannot be undone.
+</Warning>
+
+## Multi-Seat Management
+
+**MCP Tool**: `signals/get-partner-seats`
+
+For partners managing multiple brand agent seats:
+
+```json
+// List accessible seats
+{
+  "tool": "signals/get-partner-seats",
+  "parameters": {}
+}
+
+// View segments for specific seat
+{
+  "tool": "signals/list",
+  "parameters": {
+    "seatId": "seat_abc123"
+  }
+}
+```
+
+## Next Steps
+
+After creating segments, you'll need to populate them with audience data:
+
+- [Data Attachment Guide](/partners/data-attachment) - Real-time API and CSV upload methods

--- a/mintlify/reporting-overview.mdx
+++ b/mintlify/reporting-overview.mdx
@@ -16,7 +16,7 @@ Unlike basic campaign platforms, Scope3 provides enterprise-grade analytics with
     Ask questions like "How's my campaign doing?" and get rich, contextual answers
   </Card>
   <Card title="Enterprise Data Export" icon="database" color="#0D9373">
-    Export to CSV, Parquet, JSON for BI tools with flexible grouping and filtering
+    Export to CSV, JSON for BI tools with flexible grouping and filtering
   </Card>
   <Card title="ML-Powered Optimization" icon="brain" color="#0D9373">
     Statistical significance testing and AI-driven optimization recommendations
@@ -98,7 +98,7 @@ const exportResult = await exportCampaignData({
   datasets: ["delivery", "events", "tactics"],
   groupBy: ["date", "campaign", "signal", "story"],
   dateRange: { start: "2024-01-01", end: "2024-01-31" },
-  format: "parquet",
+  format: "csv",
   compression: "gzip"
 });
 
@@ -109,7 +109,7 @@ console.log(`${exportResult.totalRecords} records ready`);
 ```sql BigQuery Integration
 -- Import exported data into BigQuery
 LOAD DATA INTO campaign_performance
-FROM FILES ('gs://your-bucket/scope3_export_*.parquet.gz')
+FROM FILES ('gs://your-bucket/scope3_export_*.csv.gz')
 WITH PARTITION COLUMNS;
 
 -- Analyze signal performance
@@ -236,7 +236,7 @@ def daily_campaign_export():
         date_range={"start": yesterday, "end": yesterday},
         datasets=["delivery", "events", "tactics"],
         group_by=["date", "campaign", "signal", "story"],
-        format="parquet"
+        format="csv"
     )
     
     # Load into data warehouse

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -274,6 +274,78 @@ info:
   version: 1.0.0
 openapi: 3.1.0
 paths:
+  /signals-agent/activate:
+    post:
+      description: Tell a signals agent to activate a recommended signal by creating segments using our
+        API. The agent will handle all signal configuration details. Requires authentication.
+      operationId: signals-agent/activate
+      summary: Activate Signal
+      tags:
+        - Signals Agents
+      x-llm-hints:
+        - Use this tool when user wants to tell a signals agent to activate a recommended signal by
+          creating segments using our api
+      requestBody:
+        content:
+          application/json:
+            examples:
+              basic:
+                summary: Basic example
+                value: {}
+            schema:
+              properties:
+                agentId:
+                  type: string
+                  description: ID of the signals agent to activate the signal with
+                signalId:
+                  type: string
+                  description: Signal ID from the agent's get-signals response to activate
+              required:
+                - agentId
+                - signalId
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Successful operation
+                  value:
+                    data: {}
+                    message: Operation completed successfully
+                    success: true
+              schema:
+                properties:
+                  data:
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                properties:
+                  details:
+                    type: object
+                  error:
+                    type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+          description: Unauthorized
   /auth/check:
     post:
       description: Check the authentication status of the current API key and return user information.
@@ -2679,6 +2751,68 @@ paths:
                     type: string
                 type: object
           description: Unauthorized
+  /signals/get-partner-seats:
+    post:
+      description: Get brand agent seats (advertisers) accessible to your API key
+      operationId: signals/get-partner-seats
+      summary: Get Partner Seats
+      tags:
+        - Signals
+      x-llm-hints:
+        - Use this tool when user wants to get brand agent seats (advertisers) accessible to your
+          api key
+      requestBody:
+        content:
+          application/json:
+            examples:
+              basic:
+                summary: Basic example
+                value: {}
+            schema:
+              properties: {}
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Successful operation
+                  value:
+                    data: {}
+                    message: Operation completed successfully
+                    success: true
+              schema:
+                properties:
+                  data:
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                properties:
+                  details:
+                    type: object
+                  error:
+                    type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+          description: Unauthorized
   /product/list:
     post:
       description: Discover available advertising products from multiple sales agents based on campaign
@@ -2748,6 +2882,226 @@ paths:
                   description: Restrict to standard format types only
               required:
                 - promoted_offering
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Successful operation
+                  value:
+                    data: {}
+                    message: Operation completed successfully
+                    success: true
+              schema:
+                properties:
+                  data:
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                properties:
+                  details:
+                    type: object
+                  error:
+                    type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+          description: Unauthorized
+  /signals-agent/history:
+    post:
+      description: View complete activity history for a signals agent including all interactions, segment
+        operations, and performance metrics. Provides audit trail of agent actions. Requires
+        authentication.
+      operationId: signals-agent/history
+      summary: Get Signals Agent History
+      tags:
+        - Signals Agents
+      x-llm-hints:
+        - Use this tool when user wants to view complete activity history for a signals agent
+          including all interactions, segment operations, and performance metrics
+      requestBody:
+        content:
+          application/json:
+            examples:
+              basic:
+                summary: Basic example
+                value: {}
+            schema:
+              properties:
+                agentId:
+                  type: string
+                  description: ID of the signals agent to get history for
+                limit:
+                  type: string
+                  description: "Maximum number of activities to return (default: 50)"
+              required:
+                - agentId
+                - limit
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Successful operation
+                  value:
+                    data: {}
+                    message: Operation completed successfully
+                    success: true
+              schema:
+                properties:
+                  data:
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                properties:
+                  details:
+                    type: object
+                  error:
+                    type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+          description: Unauthorized
+  /signals-agent/get:
+    post:
+      description: Get detailed information about a specific signals agent including configuration,
+        status, and metadata. Requires authentication.
+      operationId: signals-agent/get
+      summary: Get Signals Agent
+      tags:
+        - Signals Agents
+      x-llm-hints:
+        - Use this tool when user wants to get detailed information about a specific signals agent
+          including configuration, status, and metadata
+      requestBody:
+        content:
+          application/json:
+            examples:
+              basic:
+                summary: Basic example
+                value: {}
+            schema:
+              properties:
+                agentId:
+                  type: string
+                  description: ID of the signals agent to retrieve
+              required:
+                - agentId
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Successful operation
+                  value:
+                    data: {}
+                    message: Operation completed successfully
+                    success: true
+              schema:
+                properties:
+                  data:
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                properties:
+                  details:
+                    type: object
+                  error:
+                    type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+          description: Unauthorized
+  /signals-agent/get-signals:
+    post:
+      description: Query signals agents for targeting recommendations and signal insights. Can query
+        specific agents or all active agents for a brand agent. Stateless operation that can be
+        called anytime. Requires authentication.
+      operationId: signals-agent/get-signals
+      summary: Get Signals from Agents
+      tags:
+        - Signals Agents
+      x-llm-hints:
+        - Use this tool when user wants to query signals agents for targeting recommendations and
+          signal insights
+        - Call this when user asks 'show me', 'list', or 'what are my'
+      requestBody:
+        content:
+          application/json:
+            examples:
+              basic:
+                summary: Basic example
+                value: {}
+            schema:
+              properties:
+                agentIds:
+                  items:
+                    type: string
+                  type: array
+                  description: Optional array of specific agent IDs to query. If not provided, queries all active
+                    agents.
+                brandAgentId:
+                  type: string
+                  description: ID of the brand agent to get signals for
+                brief:
+                  type: string
+                  description: Optional campaign brief or targeting description to get tailored recommendations
+              required:
+                - brandAgentId
               type: object
         required: true
       responses:
@@ -3182,8 +3536,8 @@ paths:
   /signal/list:
     post:
       description: List all custom signal definitions in the Custom Signals Platform. Optionally filter by
-        region or channel. Shows signal metadata, key types, and cluster configurations. Requires
-        authentication.
+        region, channel, or specific brand agent seat. Shows signal metadata, key types, cluster
+        configurations, and seat information for partner visibility. Requires authentication.
       operationId: signal/list
       summary: List Custom Signals
       tags:
@@ -3273,6 +3627,73 @@ paths:
                   description: Brand agent ID to list PMPs for
               required:
                 - brand_agent_id
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Successful operation
+                  value:
+                    data: {}
+                    message: Operation completed successfully
+                    success: true
+              schema:
+                properties:
+                  data:
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                properties:
+                  details:
+                    type: object
+                  error:
+                    type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+          description: Unauthorized
+  /signals-agent/list:
+    post:
+      description: List all registered signals agents for a brand agent. Shows agent status, endpoints,
+        and registration details. Requires authentication.
+      operationId: signals-agent/list
+      summary: List Signals Agents
+      tags:
+        - Signals Agents
+      x-llm-hints:
+        - Use this tool when user wants to list all registered signals agents for a brand agent
+      requestBody:
+        content:
+          application/json:
+            examples:
+              basic:
+                summary: Basic example
+                value: {}
+            schema:
+              properties:
+                brandAgentId:
+                  type: string
+                  description: ID of the brand agent to list signals agents for
+              required:
+                - brandAgentId
               type: object
         required: true
       responses:
@@ -3480,6 +3901,88 @@ paths:
                     type: string
                 type: object
           description: Unauthorized
+  /signals-agent/register:
+    post:
+      description: Register a new signals agent to your seat. The agent will receive permissions to manage
+        segments in your account using our API. Supports ADCP (Advertising Data Control Protocol)
+        compliant agents. Requires authentication.
+      operationId: signals-agent/register
+      summary: Register Signals Agent
+      tags:
+        - Signals Agents
+      x-llm-hints:
+        - Use this tool when user wants to register a new signals agent to your seat
+      requestBody:
+        content:
+          application/json:
+            examples:
+              basic:
+                summary: Basic example
+                value: {}
+            schema:
+              properties:
+                brandAgentId:
+                  type: string
+                  description: ID of the brand agent this signals agent will work with
+                config:
+                  type: string
+                  description: Optional configuration parameters for the agent
+                description:
+                  type: string
+                  description: Optional description of what this agent does
+                endpointUrl:
+                  type: string
+                  description: ADCP-compliant endpoint URL where the agent receives requests
+                name:
+                  type: string
+                  description: Human-readable name for the signals agent
+              required:
+                - brandAgentId
+                - endpointUrl
+                - name
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Successful operation
+                  value:
+                    data: {}
+                    message: Operation completed successfully
+                    success: true
+              schema:
+                properties:
+                  data:
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                properties:
+                  details:
+                    type: object
+                  error:
+                    type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+          description: Unauthorized
   /webhook/register:
     post:
       description: Register a webhook endpoint to receive real-time campaign event notifications. Supports
@@ -3568,6 +4071,74 @@ paths:
                 - brandAgentId
                 - endpoint
                 - eventTypes
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Successful operation
+                  value:
+                    data: {}
+                    message: Operation completed successfully
+                    success: true
+              schema:
+                properties:
+                  data:
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                properties:
+                  details:
+                    type: object
+                  error:
+                    type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+          description: Unauthorized
+  /signals-agent/unregister:
+    post:
+      description: Unregister a signals agent from your seat. This revokes the agent's API access and sets
+        its status to inactive. The agent will no longer be able to manage segments. Requires
+        authentication.
+      operationId: signals-agent/unregister
+      summary: Unregister Signals Agent
+      tags:
+        - Signals Agents
+      x-llm-hints:
+        - Use this tool when user wants to unregister a signals agent from your seat
+      requestBody:
+        content:
+          application/json:
+            examples:
+              basic:
+                summary: Basic example
+                value: {}
+            schema:
+              properties:
+                agentId:
+                  type: string
+                  description: ID of the signals agent to unregister
+              required:
+                - agentId
               type: object
         required: true
       responses:
@@ -4084,6 +4655,89 @@ paths:
                   description: Update the PMP status
               required:
                 - pmp_id
+              type: object
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                success:
+                  summary: Successful operation
+                  value:
+                    data: {}
+                    message: Operation completed successfully
+                    success: true
+              schema:
+                properties:
+                  data:
+                    type: object
+                  message:
+                    type: string
+                  success:
+                    type: boolean
+                type: object
+          description: Successful response
+        "400":
+          content:
+            application/json:
+              schema:
+                properties:
+                  details:
+                    type: object
+                  error:
+                    type: string
+                type: object
+          description: Bad request
+        "401":
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+          description: Unauthorized
+  /signals-agent/update:
+    post:
+      description: Update configuration and settings for a registered signals agent. Can modify name,
+        description, endpoint, status, and configuration parameters. Requires authentication.
+      operationId: signals-agent/update
+      summary: Update Signals Agent
+      tags:
+        - Signals Agents
+      x-llm-hints:
+        - Use this tool when user wants to update configuration and settings for a registered
+          signals agent
+      requestBody:
+        content:
+          application/json:
+            examples:
+              basic:
+                summary: Basic example
+                value: {}
+            schema:
+              properties:
+                agentId:
+                  type: string
+                  description: ID of the signals agent to update
+                config:
+                  type: string
+                  description: Optional configuration parameters to update
+                description:
+                  type: string
+                  description: Optional new description for the agent
+                endpointUrl:
+                  type: string
+                  description: Optional new ADCP endpoint URL
+                name:
+                  type: string
+                  description: Optional new name for the agent
+                status:
+                  type: string
+                  description: Optional new status for the agent
+              required:
+                - agentId
               type: object
         required: true
       responses:

--- a/src/client/scope3-client.ts
+++ b/src/client/scope3-client.ts
@@ -1819,6 +1819,15 @@ export class Scope3ApiClient {
     return result.data.getAPIAccessKeys.tokens[0].customerId;
   }
 
+  async validateApiKey(apiKey: string): Promise<{customerId?: number; isValid: boolean}> {
+    try {
+      const customerId = await this.getCustomerId(apiKey);
+      return { customerId, isValid: true };
+    } catch (_error) {
+      return { isValid: false };
+    }
+  }
+
   async getCustomSignal(
     apiKey: string,
     signalId: string,

--- a/src/client/scope3-client.ts
+++ b/src/client/scope3-client.ts
@@ -1911,8 +1911,6 @@ export class Scope3ApiClient {
     return mockSeats;
   }
 
-  // Inventory Option Management Methods
-
   // Get optimization recommendations
   async getOptimizationRecommendations(
     apiKey: string,
@@ -1979,6 +1977,8 @@ export class Scope3ApiClient {
   }> {
     return this.productDiscovery.getRecommendedProducts(apiKey, params);
   }
+
+  // Inventory Option Management Methods
 
   /**
    * Get list of registered sales agents for format discovery
@@ -2345,10 +2345,6 @@ export class Scope3ApiClient {
     return [];
   }
 
-  // ========================================
-  // CREATIVE MANAGEMENT METHODS (MCP Orchestration + REST)
-  // ========================================
-
   async listBrandAgents(
     apiKey: string,
     where?: BrandAgentWhereInput,
@@ -2388,6 +2384,10 @@ export class Scope3ApiClient {
 
     return result.data.brandAgents;
   }
+
+  // ========================================
+  // CREATIVE MANAGEMENT METHODS (MCP Orchestration + REST)
+  // ========================================
 
   // Brand Standards Agent methods
   async listBrandAgentStandards(
@@ -3152,10 +3152,6 @@ export class Scope3ApiClient {
     return result.data.updateBrandAgent;
   }
 
-  // ========================================
-  // PMP (PRIVATE MARKETPLACE) METHODS
-  // ========================================
-
   async updateBrandAgentCampaign(
     apiKey: string,
     id: string,
@@ -3198,6 +3194,10 @@ export class Scope3ApiClient {
 
     return result.data.updateBrandAgentCampaign;
   }
+
+  // ========================================
+  // PMP (PRIVATE MARKETPLACE) METHODS
+  // ========================================
 
   async updateBrandAgentCreative(
     apiKey: string,
@@ -3334,11 +3334,6 @@ export class Scope3ApiClient {
     return result.data.createAgentModel;
   }
 
-  // Removed parseCreativePrompt - AI generation handled by creative agents
-  // Removed detectFileFormat - handled by REST upload layer
-
-  // Custom Signal Definition Management Methods
-
   async updateBrandAgentSyntheticAudience(
     apiKey: string,
     previousModelId: string,
@@ -3394,6 +3389,11 @@ export class Scope3ApiClient {
 
     return result.data.updateBrandStory;
   }
+
+  // Removed parseCreativePrompt - AI generation handled by creative agents
+  // Removed detectFileFormat - handled by REST upload layer
+
+  // Custom Signal Definition Management Methods
 
   /**
    * Update existing creative

--- a/src/client/scope3-client.ts
+++ b/src/client/scope3-client.ts
@@ -1819,7 +1819,9 @@ export class Scope3ApiClient {
     return result.data.getAPIAccessKeys.tokens[0].customerId;
   }
 
-  async validateApiKey(apiKey: string): Promise<{customerId?: number; isValid: boolean}> {
+  async validateApiKey(
+    apiKey: string,
+  ): Promise<{ customerId?: number; isValid: boolean }> {
     try {
       const customerId = await this.getCustomerId(apiKey);
       return { customerId, isValid: true };

--- a/src/services/custom-signals-client.ts
+++ b/src/services/custom-signals-client.ts
@@ -190,7 +190,7 @@ export class CustomSignalsClient {
   async getPartnerSeats(
     scope3Client: Scope3ApiClient,
     apiKey: string,
-  ): Promise<Array<{ customerId: number; id: string; name: string; }>> {
+  ): Promise<Array<{ customerId: number; id: string; name: string }>> {
     await this.ensureInitialized();
 
     // Use the provided scope3 client to get brand agents

--- a/src/services/signals-agent-service.ts
+++ b/src/services/signals-agent-service.ts
@@ -1,0 +1,559 @@
+import { BigQuery } from "@google-cloud/bigquery";
+import { v4 as uuidv4 } from "uuid";
+
+import type {
+  ActivateSignalResponse,
+  ADCPRequest,
+  ADCPResponse,
+  GetSignalsRequest,
+  GetSignalsResponse,
+  SignalsAgent,
+  SignalsAgentActivity,
+  SignalsAgentInput,
+  SignalsAgentUpdateInput,
+} from "../types/signals-agent.js";
+
+import { AuthenticationService } from "./auth-service.js";
+import { BigQueryBaseService } from "./base/bigquery-base-service.js";
+import { SignalStorageService } from "./signal-storage-service.js";
+
+/**
+ * Service for signals agent operations backed by BigQuery
+ * Handles registration, management, and interaction with external signals agents
+ */
+export class SignalsAgentService extends BigQueryBaseService {
+  private signalStorageService: SignalStorageService;
+
+  constructor() {
+    const bigquery = new BigQuery();
+    const authService = new AuthenticationService(bigquery);
+    super(authService);
+    // Initialize signal storage service for managing segments
+    this.signalStorageService = new SignalStorageService(
+      "bok-playground", // projectId
+      "custom_signals", // datasetId
+    );
+  }
+
+  /**
+   * Tell agent to activate a signal (create segments using our API)
+   */
+  async activateSignal(
+    agentId: string,
+    signalId: string,
+  ): Promise<ActivateSignalResponse> {
+    const agent = await this.getSignalsAgent(agentId);
+    if (!agent) {
+      throw new Error(`Signals agent ${agentId} not found`);
+    }
+
+    if (agent.status !== "active") {
+      throw new Error(`Signals agent ${agent.name} is not active`);
+    }
+
+    const start = Date.now();
+
+    try {
+      const response = await this.callAgentEndpoint(agent, {
+        action: "activate_signal",
+        data: { signalId },
+        requestId: uuidv4(),
+        timestamp: new Date().toISOString(),
+      });
+
+      // Record successful activity
+      await this.recordActivity({
+        activityType: "activate_signal",
+        brandAgentId: agent.brandAgentId,
+        executedAt: new Date(),
+        id: uuidv4(),
+        request: { signalId },
+        response,
+        responseTimeMs: Date.now() - start,
+        segmentIds:
+          (response.segmentIds as string[]) ||
+          (response.segmentId ? [response.segmentId as string] : undefined),
+        signalsAgentId: agentId,
+        status: "success",
+      });
+
+      return {
+        segmentId: response.segmentId as string,
+        segmentIds: response.segmentIds as string[],
+      };
+    } catch (error) {
+      // Record failed activity
+      await this.recordActivity({
+        activityType: "activate_signal",
+        brandAgentId: agent.brandAgentId,
+        errorDetails: error instanceof Error ? error.message : String(error),
+        executedAt: new Date(),
+        id: uuidv4(),
+        request: { signalId },
+        responseTimeMs: Date.now() - start,
+        signalsAgentId: agentId,
+        status: "failed",
+      });
+
+      throw error;
+    }
+  }
+
+  /**
+   * Get activity history for a signals agent
+   */
+  async getAgentHistory(
+    agentId: string,
+    limit: number = 50,
+  ): Promise<SignalsAgentActivity[]> {
+    const query = `
+      SELECT 
+        id,
+        signals_agent_id,
+        brand_agent_id,
+        activity_type,
+        request,
+        response,
+        segment_ids,
+        status,
+        response_time_ms,
+        error_details,
+        executed_at
+      FROM ${this.getTableRef("signals_agent_activity")}
+      WHERE signals_agent_id = @agentId
+      ORDER BY executed_at DESC
+      LIMIT @limit
+    `;
+
+    const rows = await this.executeQuery(query, { agentId, limit });
+
+    return rows.map((row) =>
+      this.mapRowToActivity(row as Record<string, unknown>),
+    );
+  }
+
+  /**
+   * Get signals from one or more agents
+   */
+  async getSignals(
+    brandAgentId: string,
+    agentIds?: string[],
+    brief?: string,
+  ): Promise<GetSignalsResponse[]> {
+    let agents: SignalsAgent[];
+
+    if (agentIds && agentIds.length > 0) {
+      // Get specific agents
+      agents = await this.getAgentsByIds(agentIds);
+    } else {
+      // Get all active agents for the brand agent
+      agents = (await this.listSignalsAgents(brandAgentId)).filter(
+        (a) => a.status === "active",
+      );
+    }
+
+    const responses = await Promise.allSettled(
+      agents.map(async (agent) => {
+        const start = Date.now();
+        try {
+          const response = await this.queryAgent(agent, {
+            brief,
+            context: { brandAgentId },
+          });
+
+          // Record successful activity
+          await this.recordActivity({
+            activityType: "get_signals",
+            brandAgentId,
+            executedAt: new Date(),
+            id: uuidv4(),
+            request: { agentId: agent.id, brief },
+            response,
+            responseTimeMs: Date.now() - start,
+            signalsAgentId: agent.id,
+            status: "success",
+          });
+
+          return {
+            agentId: agent.id,
+            agentName: agent.name,
+            metadata: response.metadata,
+            signals: response.signals || [],
+          } as GetSignalsResponse;
+        } catch (error) {
+          // Record failed activity
+          await this.recordActivity({
+            activityType: "get_signals",
+            brandAgentId,
+            errorDetails:
+              error instanceof Error ? error.message : String(error),
+            executedAt: new Date(),
+            id: uuidv4(),
+            request: { agentId: agent.id, brief },
+            responseTimeMs: Date.now() - start,
+            signalsAgentId: agent.id,
+            status: "failed",
+          });
+
+          throw error;
+        }
+      }),
+    );
+
+    // Return only successful responses
+    return responses
+      .filter(
+        (result): result is PromiseFulfilledResult<GetSignalsResponse> =>
+          result.status === "fulfilled",
+      )
+      .map((result) => result.value);
+  }
+
+  /**
+   * Get signals agent by ID
+   */
+  async getSignalsAgent(agentId: string): Promise<null | SignalsAgent> {
+    const query = `
+      SELECT 
+        id,
+        brand_agent_id,
+        name,
+        description,
+        endpoint_url,
+        status,
+        config,
+        registered_at,
+        registered_by,
+        updated_at
+      FROM ${this.getTableRef("signals_agents")}
+      WHERE id = @agentId
+      LIMIT 1
+    `;
+
+    const row = await this.executeQuerySingle(query, { agentId });
+    if (!row) return null;
+
+    return this.mapRowToSignalsAgent(row as Record<string, unknown>);
+  }
+
+  /**
+   * List signals agents for a brand agent
+   */
+  async listSignalsAgents(brandAgentId: string): Promise<SignalsAgent[]> {
+    const query = `
+      SELECT 
+        id,
+        brand_agent_id,
+        name,
+        description,
+        endpoint_url,
+        status,
+        config,
+        registered_at,
+        registered_by,
+        updated_at
+      FROM ${this.getTableRef("signals_agents")}
+      WHERE brand_agent_id = @brandAgentId
+      ORDER BY registered_at DESC
+    `;
+
+    const rows = await this.executeQuery(query, { brandAgentId });
+
+    return rows.map((row) =>
+      this.mapRowToSignalsAgent(row as Record<string, unknown>),
+    );
+  }
+
+  /**
+   * Record activity for audit trail
+   */
+  async recordActivity(activity: SignalsAgentActivity): Promise<void> {
+    const query = `
+      INSERT INTO ${this.getTableRef("signals_agent_activity")}
+      (id, signals_agent_id, brand_agent_id, activity_type, request, response, segment_ids, status, response_time_ms, error_details, executed_at)
+      VALUES (@id, @signalsAgentId, @brandAgentId, @activityType, @request, @response, @segmentIds, @status, @responseTimeMs, @errorDetails, @executedAt)
+    `;
+
+    await this.executeQuery(query, {
+      activityType: activity.activityType,
+      brandAgentId: activity.brandAgentId,
+      errorDetails: activity.errorDetails || null,
+      executedAt: activity.executedAt.toISOString(),
+      id: activity.id,
+      request: activity.request ? JSON.stringify(activity.request) : null,
+      response: activity.response ? JSON.stringify(activity.response) : null,
+      responseTimeMs: activity.responseTimeMs || null,
+      segmentIds: activity.segmentIds || null,
+      signalsAgentId: activity.signalsAgentId,
+      status: activity.status,
+    });
+  }
+
+  /**
+   * Register a new signals agent
+   */
+  async registerSignalsAgent(
+    data: SignalsAgentInput,
+    _customerId: number,
+  ): Promise<SignalsAgent> {
+    const agentId = uuidv4();
+    const now = this.getCurrentTimestamp();
+
+    const query = `
+      INSERT INTO ${this.getTableRef("signals_agents")}
+      (id, brand_agent_id, name, description, endpoint_url, status, config, registered_at, registered_by, updated_at)
+      VALUES (@agentId, @brandAgentId, @name, @description, @endpointUrl, 'active', @config, ${now}, @registeredBy, ${now})
+    `;
+
+    await this.executeQuery(query, {
+      agentId,
+      brandAgentId: data.brandAgentId,
+      config: data.config ? JSON.stringify(data.config) : null,
+      description: data.description || null,
+      endpointUrl: data.endpointUrl,
+      name: data.name,
+      registeredBy: data.registeredBy || null,
+    });
+
+    const agent = await this.getSignalsAgent(agentId);
+    if (!agent) {
+      throw new Error("Failed to retrieve created signals agent");
+    }
+
+    // Record the registration activity
+    await this.recordActivity({
+      activityType: "get_signals", // Use as generic registration activity
+      brandAgentId: data.brandAgentId,
+      executedAt: new Date(),
+      id: uuidv4(),
+      request: { action: "register", data },
+      responseTimeMs: 0,
+      signalsAgentId: agentId,
+      status: "success",
+    });
+
+    return agent;
+  }
+
+  /**
+   * Unregister (soft delete) a signals agent
+   */
+  async unregisterSignalsAgent(agentId: string): Promise<void> {
+    const query = `
+      UPDATE ${this.getTableRef("signals_agents")}
+      SET status = 'inactive', updated_at = ${this.getCurrentTimestamp()}
+      WHERE id = @agentId
+    `;
+
+    await this.executeQuery(query, { agentId });
+  }
+
+  /**
+   * Update signals agent
+   */
+  async updateSignalsAgent(
+    agentId: string,
+    data: SignalsAgentUpdateInput,
+  ): Promise<SignalsAgent> {
+    const updateFields: string[] = [];
+    const params: Record<string, unknown> = { agentId };
+
+    if (data.name) {
+      updateFields.push("name = @name");
+      params.name = data.name;
+    }
+
+    if (data.description !== undefined) {
+      updateFields.push("description = @description");
+      params.description = data.description || null;
+    }
+
+    if (data.endpointUrl) {
+      updateFields.push("endpoint_url = @endpointUrl");
+      params.endpointUrl = data.endpointUrl;
+    }
+
+    if (data.status) {
+      updateFields.push("status = @status");
+      params.status = data.status;
+    }
+
+    if (data.config) {
+      updateFields.push("config = @config");
+      params.config = JSON.stringify(data.config);
+    }
+
+    if (updateFields.length === 0) {
+      throw new Error("No fields to update");
+    }
+
+    updateFields.push(`updated_at = ${this.getCurrentTimestamp()}`);
+
+    const query = `
+      UPDATE ${this.getTableRef("signals_agents")}
+      SET ${updateFields.join(", ")}
+      WHERE id = @agentId
+    `;
+
+    await this.executeQuery(query, params);
+
+    const agent = await this.getSignalsAgent(agentId);
+    if (!agent) {
+      throw new Error("Failed to retrieve updated signals agent");
+    }
+
+    return agent;
+  }
+
+  /**
+   * Call agent endpoint for activation
+   */
+  private async callAgentEndpoint(
+    agent: SignalsAgent,
+    request: ADCPRequest,
+  ): Promise<Record<string, unknown>> {
+    const response = await fetch(agent.endpointUrl, {
+      body: JSON.stringify(request),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Agent ${agent.name} returned ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    const adcpResponse = (await response.json()) as ADCPResponse;
+
+    if (adcpResponse.status === "error") {
+      throw new Error(
+        `Agent ${agent.name} error: ${adcpResponse.error?.message || "Unknown error"}`,
+      );
+    }
+
+    return adcpResponse.data || {};
+  }
+
+  /**
+   * Get agents by IDs
+   */
+  private async getAgentsByIds(agentIds: string[]): Promise<SignalsAgent[]> {
+    if (agentIds.length === 0) return [];
+
+    const placeholders = agentIds.map((_, i) => `@agentId${i}`).join(", ");
+    const params: Record<string, unknown> = {};
+    agentIds.forEach((id, i) => {
+      params[`agentId${i}`] = id;
+    });
+
+    const query = `
+      SELECT 
+        id,
+        brand_agent_id,
+        name,
+        description,
+        endpoint_url,
+        status,
+        config,
+        registered_at,
+        registered_by,
+        updated_at
+      FROM ${this.getTableRef("signals_agents")}
+      WHERE id IN (${placeholders})
+      AND status = 'active'
+      ORDER BY registered_at DESC
+    `;
+
+    const rows = await this.executeQuery(query, params);
+
+    return rows.map((row) =>
+      this.mapRowToSignalsAgent(row as Record<string, unknown>),
+    );
+  }
+
+  /**
+   * Map database row to SignalsAgentActivity
+   */
+  private mapRowToActivity(row: Record<string, unknown>): SignalsAgentActivity {
+    return {
+      activityType: String(
+        row.activity_type,
+      ) as SignalsAgentActivity["activityType"],
+      brandAgentId: String(row.brand_agent_id),
+      errorDetails: row.error_details ? String(row.error_details) : undefined,
+      executedAt: new Date(row.executed_at as Date | number | string),
+      id: String(row.id),
+      request: row.request ? JSON.parse(String(row.request)) : undefined,
+      response: row.response ? JSON.parse(String(row.response)) : undefined,
+      responseTimeMs: row.response_time_ms
+        ? Number(row.response_time_ms)
+        : undefined,
+      segmentIds: Array.isArray(row.segment_ids)
+        ? (row.segment_ids as string[])
+        : undefined,
+      signalsAgentId: String(row.signals_agent_id),
+      status: String(row.status) as "failed" | "success" | "timeout",
+    };
+  }
+
+  /**
+   * Map database row to SignalsAgent
+   */
+  private mapRowToSignalsAgent(row: Record<string, unknown>): SignalsAgent {
+    return {
+      brandAgentId: String(row.brand_agent_id),
+      config: row.config ? JSON.parse(String(row.config)) : undefined,
+      createdAt: new Date(row.registered_at as Date | number | string),
+      description: row.description ? String(row.description) : undefined,
+      endpointUrl: String(row.endpoint_url),
+      id: String(row.id),
+      name: String(row.name),
+      registeredAt: new Date(row.registered_at as Date | number | string),
+      registeredBy: row.registered_by ? String(row.registered_by) : undefined,
+      status: String(row.status) as "active" | "inactive" | "suspended",
+      updatedAt: new Date(row.updated_at as Date | number | string),
+    };
+  }
+
+  /**
+   * Query an external signals agent via ADCP protocol
+   */
+  private async queryAgent(
+    agent: SignalsAgent,
+    request: GetSignalsRequest,
+  ): Promise<Record<string, unknown>> {
+    const adcpRequest: ADCPRequest = {
+      action: "get_signals",
+      data: request as Record<string, unknown>,
+      requestId: uuidv4(),
+      timestamp: new Date().toISOString(),
+    };
+
+    const response = await fetch(agent.endpointUrl, {
+      body: JSON.stringify(adcpRequest),
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Agent ${agent.name} returned ${response.status}: ${response.statusText}`,
+      );
+    }
+
+    const adcpResponse = (await response.json()) as ADCPResponse;
+
+    if (adcpResponse.status === "error") {
+      throw new Error(
+        `Agent ${agent.name} error: ${adcpResponse.error?.message || "Unknown error"}`,
+      );
+    }
+
+    return adcpResponse.data || {};
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -53,9 +53,19 @@ import { getProductsTool } from "./products/list.js";
 import { exportDataTool } from "./reporting/export-data.js";
 // Reporting
 import { provideScoringOutcomesTool } from "./reporting/provide-outcomes.js";
+// Signals Agents
+import { activateSignalTool } from "./signals-agents/activate.js";
+import { getSignalsTool } from "./signals-agents/get-signals.js";
+import { getSignalsAgentTool } from "./signals-agents/get.js";
+import { getSignalsAgentHistoryTool } from "./signals-agents/history.js";
+import { listSignalsAgentsTool } from "./signals-agents/list.js";
+import { registerSignalsAgentTool } from "./signals-agents/register.js";
+import { unregisterSignalsAgentTool } from "./signals-agents/unregister.js";
+import { updateSignalsAgentTool } from "./signals-agents/update.js";
 // Signals
 import { createCustomSignalTool } from "./signals/create.js";
 import { deleteCustomSignalTool } from "./signals/delete.js";
+import { getPartnerSeatsTool } from "./signals/get-partner-seats.js";
 import { getCustomSignalTool } from "./signals/get.js";
 import { listCustomSignalsTool } from "./signals/list.js";
 import { updateCustomSignalTool } from "./signals/update.js";
@@ -124,6 +134,17 @@ export const registerTools = (server: FastMCP, client: Scope3ApiClient) => {
   server.addTool(listCustomSignalsTool(client)); // signal/list
   server.addTool(updateCustomSignalTool(client)); // signal/update
   server.addTool(deleteCustomSignalTool(client)); // signal/delete
+  server.addTool(getPartnerSeatsTool(client)); // signals/get-partner-seats
+
+  // Signals Agents
+  server.addTool(registerSignalsAgentTool(client)); // signals-agent/register
+  server.addTool(listSignalsAgentsTool(client)); // signals-agent/list
+  server.addTool(getSignalsAgentTool(client)); // signals-agent/get
+  server.addTool(updateSignalsAgentTool(client)); // signals-agent/update
+  server.addTool(unregisterSignalsAgentTool(client)); // signals-agent/unregister
+  server.addTool(getSignalsTool(client)); // signals-agent/get-signals
+  server.addTool(activateSignalTool(client)); // signals-agent/activate
+  server.addTool(getSignalsAgentHistoryTool(client)); // signals-agent/history
 
   // Reporting
   server.addTool(provideScoringOutcomesTool(client)); // reporting/provide-outcomes
@@ -146,6 +167,7 @@ export const registerTools = (server: FastMCP, client: Scope3ApiClient) => {
 
 // Export individual tools for testing
 export {
+  activateSignalTool,
   // Asset Management
   // Campaigns
   // Authentication
@@ -186,8 +208,12 @@ export {
   getCustomSignalTool,
   // DSP
   getDSPSeatsTool,
+  getPartnerSeatsTool,
   // Products
   getProductsTool,
+  getSignalsAgentHistoryTool,
+  getSignalsAgentTool,
+  getSignalsTool,
   listBrandAgentBrandStoriesTool,
   listBrandAgentStandardsTool,
   listBrandAgentsTool,
@@ -195,14 +221,19 @@ export {
   listCreativeFormatsTool,
   listCustomSignalsTool,
   listPMPsTool,
+  listSignalsAgentsTool,
   listTacticsTool,
   provideScoringOutcomesTool,
+  // Signals Agents
+  registerSignalsAgentTool,
   // Webhooks
   registerWebhookTool,
+  unregisterSignalsAgentTool,
   updateBrandAgentBrandStoryTool,
   updateBrandAgentStandardsTool,
   updateBrandAgentTool,
   updateCampaignTool,
   updateCustomSignalTool,
   updatePMPTool,
+  updateSignalsAgentTool,
 };

--- a/src/tools/signals-agents/activate.ts
+++ b/src/tools/signals-agents/activate.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+
+import type { Scope3ApiClient } from "../../client/scope3-client.js";
+import type {
+  ActivateSignalParams,
+  MCPToolExecuteContext,
+} from "../../types/mcp.js";
+
+import { SignalsAgentService } from "../../services/signals-agent-service.js";
+import {
+  createAuthErrorResponse,
+  createErrorResponse,
+  createMCPResponse,
+} from "../../utils/error-handling.js";
+
+export const activateSignalTool = (client: Scope3ApiClient) => ({
+  annotations: {
+    category: "Signals Agents",
+    dangerLevel: "medium",
+    openWorldHint: true,
+    readOnlyHint: false,
+    title: "Activate Signal",
+  },
+
+  description:
+    "Tell a signals agent to activate a recommended signal by creating segments using our API. The agent will handle all signal configuration details. Requires authentication.",
+
+  execute: async (
+    args: ActivateSignalParams,
+    context: MCPToolExecuteContext,
+  ): Promise<string> => {
+    // Check session context first, then fall back to environment variable
+    let apiKey = context.session?.scope3ApiKey;
+
+    if (!apiKey) {
+      apiKey = process.env.SCOPE3_API_KEY;
+    }
+
+    if (!apiKey) {
+      return createAuthErrorResponse();
+    }
+
+    try {
+      // Validate API key
+      const authResult = await client.validateApiKey(apiKey);
+      if (!authResult.isValid) {
+        return createAuthErrorResponse();
+      }
+
+      const signalsAgentService = new SignalsAgentService();
+
+      // Get agent details for better error messages
+      const agent = await signalsAgentService.getSignalsAgent(args.agentId);
+      if (!agent) {
+        return createErrorResponse(
+          `Signals agent ${args.agentId} not found`,
+          null,
+        );
+      }
+
+      if (agent.status !== "active") {
+        return createErrorResponse(
+          `Signals agent "${agent.name}" is ${agent.status} and cannot activate signals`,
+          null,
+        );
+      }
+
+      const result = await signalsAgentService.activateSignal(
+        args.agentId,
+        args.signalId,
+      );
+
+      let summary = `✅ Signal Activated Successfully!\n\n`;
+      summary += `**Activation Details:**\n`;
+      summary += `• **Agent:** ${agent.name}\n`;
+      summary += `• **Agent ID:** ${args.agentId}\n`;
+      summary += `• **Signal ID:** ${args.signalId}\n`;
+      summary += `• **Activation Time:** ${new Date().toLocaleString()}\n\n`;
+
+      summary += `**Created Segments:**\n`;
+      if (result.segmentIds && result.segmentIds.length > 1) {
+        summary += `• **Primary Segment:** ${result.segmentId}\n`;
+        summary += `• **Additional Segments:** ${result.segmentIds.length - 1}\n`;
+        summary += `• **Total Segments:** ${result.segmentIds.length}\n`;
+
+        summary += `\n**All Segment IDs:**\n`;
+        result.segmentIds.forEach((id, index) => {
+          summary += `• ${index + 1}. ${id}\n`;
+        });
+      } else {
+        summary += `• **Segment ID:** ${result.segmentId}\n`;
+      }
+      summary += `\n`;
+
+      summary += `**🔄 What Happened:**\n`;
+      summary += `1. Your request was sent to the signals agent\n`;
+      summary += `2. The agent processed the signal activation request\n`;
+      summary += `3. The agent used its API credentials to create segment(s)\n`;
+      summary += `4. The segment(s) are now managed by the agent\n`;
+      summary += `5. All activity has been logged for audit trail\n\n`;
+
+      summary += `**📊 Segment Management:**\n`;
+      summary += `• The signals agent now owns and manages these segments\n`;
+      summary += `• Only this agent can update or delete these segments\n`;
+      summary += `• Segment data will be handled according to agent's configuration\n`;
+      summary += `• Use \`signal/list\` to view all segments (including agent-managed)\n\n`;
+
+      summary += `**Next Steps:**\n`;
+      summary += `• Use the segment ID(s) in campaign targeting\n`;
+      summary += `• Monitor segment performance through campaign analytics\n`;
+      summary += `• Use \`signals-agent/history\` to track agent activities\n`;
+      summary += `• Query the agent again for additional recommendations\n\n`;
+
+      summary += `**Campaign Integration:**\n`;
+      summary += `\`\`\`javascript\n`;
+      summary += `// Use the activated segment in a campaign\n`;
+      summary += `const campaign = await createCampaign({\n`;
+      summary += `  brandAgentId: "${agent.brandAgentId}",\n`;
+      summary += `  name: "Campaign with Agent-Optimized Segments",\n`;
+      summary += `  prompt: "Target using signals agent recommendations",\n`;
+      summary += `  // The segment will be automatically considered for targeting\n`;
+      summary += `});\n`;
+      summary += `\`\`\`\n\n`;
+
+      summary += `The signal has been successfully activated and is ready for use!`;
+
+      return createMCPResponse({
+        message: summary,
+        success: true,
+      });
+    } catch (error) {
+      return createErrorResponse("Failed to activate signal", error);
+    }
+  },
+
+  name: "signals-agent/activate",
+  parameters: z.object({
+    agentId: z
+      .string()
+      .describe("ID of the signals agent to activate the signal with"),
+    signalId: z
+      .string()
+      .describe("Signal ID from the agent's get-signals response to activate"),
+  }),
+});

--- a/src/tools/signals-agents/get-signals.ts
+++ b/src/tools/signals-agents/get-signals.ts
@@ -1,0 +1,222 @@
+import { z } from "zod";
+
+import type { Scope3ApiClient } from "../../client/scope3-client.js";
+import type {
+  GetSignalsParams,
+  MCPToolExecuteContext,
+} from "../../types/mcp.js";
+
+import { SignalsAgentService } from "../../services/signals-agent-service.js";
+import {
+  createAuthErrorResponse,
+  createErrorResponse,
+  createMCPResponse,
+} from "../../utils/error-handling.js";
+
+export const getSignalsTool = (client: Scope3ApiClient) => ({
+  annotations: {
+    category: "Signals Agents",
+    dangerLevel: "low",
+    openWorldHint: true,
+    readOnlyHint: true,
+    title: "Get Signals from Agents",
+  },
+
+  description:
+    "Query signals agents for targeting recommendations and signal insights. Can query specific agents or all active agents for a brand agent. Stateless operation that can be called anytime. Requires authentication.",
+
+  execute: async (
+    args: GetSignalsParams,
+    context: MCPToolExecuteContext,
+  ): Promise<string> => {
+    // Check session context first, then fall back to environment variable
+    let apiKey = context.session?.scope3ApiKey;
+
+    if (!apiKey) {
+      apiKey = process.env.SCOPE3_API_KEY;
+    }
+
+    if (!apiKey) {
+      return createAuthErrorResponse();
+    }
+
+    try {
+      // Validate API key
+      const authResult = await client.validateApiKey(apiKey);
+      if (!authResult.isValid) {
+        return createAuthErrorResponse();
+      }
+
+      const signalsAgentService = new SignalsAgentService();
+      const responses = await signalsAgentService.getSignals(
+        args.brandAgentId,
+        args.agentIds,
+        args.brief,
+      );
+
+      if (responses.length === 0) {
+        let summary = `📭 **No Signal Responses**\n\n`;
+        summary += `**Brand Agent:** ${args.brandAgentId}\n`;
+        if (args.agentIds?.length) {
+          summary += `**Queried Agents:** ${args.agentIds.length}\n`;
+        }
+        if (args.brief) {
+          summary += `**Brief:** "${args.brief}"\n`;
+        }
+        summary += `\n`;
+
+        summary += `**Possible Reasons:**\n`;
+        summary += `• No active signals agents registered\n`;
+        summary += `• All agents failed to respond\n`;
+        summary += `• Agents returned empty signal lists\n`;
+        summary += `• Network connectivity issues\n\n`;
+
+        summary += `**Next Steps:**\n`;
+        summary += `• Use \`signals-agent/list\` to check registered agents\n`;
+        summary += `• Use \`signals-agent/history\` to check for errors\n`;
+        summary += `• Register new agents with \`signals-agent/register\`\n`;
+
+        return createMCPResponse({
+          message: summary,
+          success: true,
+        });
+      }
+
+      let summary = `🎯 **Signal Recommendations**\n\n`;
+      summary += `**Brand Agent:** ${args.brandAgentId}\n`;
+      summary += `**Responding Agents:** ${responses.length}\n`;
+      if (args.brief) {
+        summary += `**Brief:** "${args.brief}"\n`;
+      }
+      summary += `**Query Time:** ${new Date().toLocaleString()}\n\n`;
+
+      // Show signals by agent
+      responses.forEach((response, index) => {
+        summary += `## ${index + 1}. ${response.agentName}\n`;
+        summary += `**Agent ID:** ${response.agentId}\n`;
+
+        if (response.signals && response.signals.length > 0) {
+          summary += `**Signals:** ${response.signals.length}\n\n`;
+
+          response.signals.forEach((signal, signalIndex) => {
+            summary += `### Signal ${signalIndex + 1}: ${signal.name}\n`;
+            summary += `• **Description:** ${signal.description}\n`;
+            summary += `• **Key Type:** ${signal.keyType}\n`;
+
+            if (signal.clusters && signal.clusters.length > 0) {
+              const regions = [
+                ...new Set(signal.clusters.map((c) => c.region)),
+              ];
+              summary += `• **Regions:** ${regions.join(", ")}\n`;
+
+              const channels = signal.clusters
+                .map((c) => c.channel)
+                .filter(Boolean);
+              if (channels.length > 0) {
+                summary += `• **Channels:** ${[...new Set(channels)].join(", ")}\n`;
+              }
+
+              const gdprClusters = signal.clusters.filter((c) => c.gdpr).length;
+              if (gdprClusters > 0) {
+                summary += `• **GDPR Compliant:** ${gdprClusters} cluster(s)\n`;
+              }
+            }
+
+            if (signal.confidence !== undefined) {
+              summary += `• **Confidence:** ${(signal.confidence * 100).toFixed(1)}%\n`;
+            }
+
+            if (signal.reasoning) {
+              summary += `• **Reasoning:** ${signal.reasoning}\n`;
+            }
+
+            if (signal.id) {
+              summary += `• **Signal ID:** \`${signal.id}\` (use with activate)\n`;
+            }
+
+            summary += `\n`;
+          });
+        } else {
+          summary += `**Signals:** 0 (no recommendations)\n\n`;
+        }
+
+        if (response.metadata && Object.keys(response.metadata).length > 0) {
+          summary += `**Additional Metadata:**\n`;
+          Object.entries(response.metadata).forEach(([key, value]) => {
+            summary += `• **${key}:** ${String(value)}\n`;
+          });
+          summary += `\n`;
+        }
+      });
+
+      // Summary statistics
+      const totalSignals = responses.reduce(
+        (sum, r) => sum + (r.signals?.length || 0),
+        0,
+      );
+      const highConfidenceSignals = responses.reduce(
+        (sum, r) =>
+          sum +
+          (r.signals?.filter((s) => (s.confidence || 0) > 0.8).length || 0),
+        0,
+      );
+
+      summary += `## 📊 Summary\n\n`;
+      summary += `• **Total Signals:** ${totalSignals}\n`;
+      summary += `• **High Confidence:** ${highConfidenceSignals} (>80%)\n`;
+      summary += `• **Unique Agents:** ${responses.length}\n`;
+
+      // Show available signal IDs for activation
+      const activatableSignals = responses.flatMap(
+        (r) =>
+          r.signals
+            ?.filter((s) => s.id)
+            .map((s) => ({
+              agentId: r.agentId,
+              agentName: r.agentName,
+              signalId: s.id,
+              signalName: s.name,
+            })) || [],
+      );
+
+      if (activatableSignals.length > 0) {
+        summary += `\n**🚀 Ready to Activate:**\n`;
+        activatableSignals.forEach((signal) => {
+          summary += `• \`signals-agent/activate ${signal.agentId} ${signal.signalId}\` - ${signal.signalName}\n`;
+        });
+        summary += `\n`;
+      }
+
+      summary += `**Next Steps:**\n`;
+      summary += `• Use \`signals-agent/activate\` to create recommended segments\n`;
+      summary += `• Use \`signals-agent/history\` to view detailed interaction logs\n`;
+      summary += `• Refine your brief and query again for different recommendations\n`;
+
+      return createMCPResponse({
+        message: summary,
+        success: true,
+      });
+    } catch (error) {
+      return createErrorResponse("Failed to get signals from agents", error);
+    }
+  },
+
+  name: "signals-agent/get-signals",
+  parameters: z.object({
+    agentIds: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Optional array of specific agent IDs to query. If not provided, queries all active agents.",
+      ),
+    brandAgentId: z
+      .string()
+      .describe("ID of the brand agent to get signals for"),
+    brief: z
+      .string()
+      .optional()
+      .describe(
+        "Optional campaign brief or targeting description to get tailored recommendations",
+      ),
+  }),
+});

--- a/src/tools/signals-agents/get.ts
+++ b/src/tools/signals-agents/get.ts
@@ -1,0 +1,162 @@
+import { z } from "zod";
+
+import type { Scope3ApiClient } from "../../client/scope3-client.js";
+import type {
+  GetSignalsAgentParams,
+  MCPToolExecuteContext,
+} from "../../types/mcp.js";
+
+import { SignalsAgentService } from "../../services/signals-agent-service.js";
+import {
+  createAuthErrorResponse,
+  createErrorResponse,
+  createMCPResponse,
+} from "../../utils/error-handling.js";
+
+export const getSignalsAgentTool = (client: Scope3ApiClient) => ({
+  annotations: {
+    category: "Signals Agents",
+    dangerLevel: "low",
+    openWorldHint: true,
+    readOnlyHint: true,
+    title: "Get Signals Agent",
+  },
+
+  description:
+    "Get detailed information about a specific signals agent including configuration, status, and metadata. Requires authentication.",
+
+  execute: async (
+    args: GetSignalsAgentParams,
+    context: MCPToolExecuteContext,
+  ): Promise<string> => {
+    // Check session context first, then fall back to environment variable
+    let apiKey = context.session?.scope3ApiKey;
+
+    if (!apiKey) {
+      apiKey = process.env.SCOPE3_API_KEY;
+    }
+
+    if (!apiKey) {
+      return createAuthErrorResponse();
+    }
+
+    try {
+      // Validate API key
+      const authResult = await client.validateApiKey(apiKey);
+      if (!authResult.isValid) {
+        return createAuthErrorResponse();
+      }
+
+      const signalsAgentService = new SignalsAgentService();
+      const agent = await signalsAgentService.getSignalsAgent(args.agentId);
+
+      if (!agent) {
+        return createErrorResponse(
+          `Signals agent ${args.agentId} not found`,
+          null,
+        );
+      }
+
+      let summary = `🤖 **Signals Agent Details**\n\n`;
+      summary += `**Basic Information:**\n`;
+      summary += `• **ID:** ${agent.id}\n`;
+      summary += `• **Name:** ${agent.name}\n`;
+      summary += `• **Status:** ${agent.status.toUpperCase()}\n`;
+      summary += `• **Brand Agent:** ${agent.brandAgentId}\n`;
+
+      if (agent.description) {
+        summary += `• **Description:** ${agent.description}\n`;
+      }
+      summary += `\n`;
+
+      summary += `**Technical Configuration:**\n`;
+      summary += `• **Endpoint URL:** ${agent.endpointUrl}\n`;
+      summary += `• **Protocol:** ADCP (Advertising Data Control Protocol)\n`;
+      summary += `• **Registered:** ${new Date(agent.registeredAt).toLocaleString()}\n`;
+      summary += `• **Last Updated:** ${new Date(agent.updatedAt).toLocaleString()}\n`;
+
+      if (agent.registeredBy) {
+        summary += `• **Registered by:** ${agent.registeredBy}\n`;
+      }
+      summary += `\n`;
+
+      if (agent.config && Object.keys(agent.config).length > 0) {
+        summary += `**Configuration Parameters:**\n`;
+        Object.entries(agent.config).forEach(([key, value]) => {
+          summary += `• **${key}:** ${JSON.stringify(value)}\n`;
+        });
+        summary += `\n`;
+      }
+
+      summary += `**Status Details:**\n`;
+      switch (agent.status) {
+        case "active":
+          summary += `• ✅ Agent is active and ready to process requests\n`;
+          summary += `• Can receive get-signals and activate-signal requests\n`;
+          summary += `• Authorized to manage segments via API\n`;
+          break;
+        case "inactive":
+          summary += `• ⭕ Agent is inactive and will not process requests\n`;
+          summary += `• Cannot create or manage segments\n`;
+          summary += `• May be temporarily disabled\n`;
+          break;
+        case "suspended":
+          summary += `• ⛔ Agent is suspended due to errors or policy violations\n`;
+          summary += `• All API access has been revoked\n`;
+          summary += `• Manual review required for reactivation\n`;
+          break;
+      }
+      summary += `\n`;
+
+      summary += `**Available Actions:**\n`;
+      if (agent.status === "active") {
+        summary += `• \`signals-agent/get-signals\` - Query this agent for recommendations\n`;
+        summary += `• \`signals-agent/activate\` - Tell this agent to create segments\n`;
+      }
+      summary += `• \`signals-agent/history\` - View this agent's activity log\n`;
+      summary += `• \`signals-agent/update\` - Modify agent configuration\n`;
+      summary += `• \`signals-agent/unregister\` - Remove agent registration\n\n`;
+
+      summary += `**Integration Information:**\n`;
+      summary += `• **ADCP Endpoint:** \`POST ${agent.endpointUrl}\`\n`;
+      summary += `• **Expected Request Format:**\n`;
+      summary += `  \`\`\`json\n`;
+      summary += `  {\n`;
+      summary += `    "action": "get_signals" | "activate_signal",\n`;
+      summary += `    "data": { ... },\n`;
+      summary += `    "requestId": "uuid",\n`;
+      summary += `    "timestamp": "2024-01-01T00:00:00Z"\n`;
+      summary += `  }\n`;
+      summary += `  \`\`\`\n`;
+      summary += `• **Expected Response Format:**\n`;
+      summary += `  \`\`\`json\n`;
+      summary += `  {\n`;
+      summary += `    "status": "success" | "error",\n`;
+      summary += `    "data": { ... },\n`;
+      summary += `    "requestId": "uuid",\n`;
+      summary += `    "timestamp": "2024-01-01T00:00:00Z"\n`;
+      summary += `  }\n`;
+      summary += `  \`\`\`\n\n`;
+
+      if (agent.status === "active") {
+        summary += `**Quick Test:**\n`;
+        summary += `\`\`\`bash\n`;
+        summary += `# Query this agent for signals\n`;
+        summary += `signals-agent/get-signals ${agent.brandAgentId} --agent-ids ${agent.id} --brief "Test brief"\n`;
+        summary += `\`\`\``;
+      }
+
+      return createMCPResponse({
+        message: summary,
+        success: true,
+      });
+    } catch (error) {
+      return createErrorResponse("Failed to get signals agent", error);
+    }
+  },
+
+  name: "signals-agent/get",
+  parameters: z.object({
+    agentId: z.string().describe("ID of the signals agent to retrieve"),
+  }),
+});

--- a/src/tools/signals-agents/history.ts
+++ b/src/tools/signals-agents/history.ts
@@ -1,0 +1,253 @@
+import { z } from "zod";
+
+import type { Scope3ApiClient } from "../../client/scope3-client.js";
+import type {
+  GetSignalsAgentHistoryParams,
+  MCPToolExecuteContext,
+} from "../../types/mcp.js";
+
+import { SignalsAgentService } from "../../services/signals-agent-service.js";
+import {
+  createAuthErrorResponse,
+  createErrorResponse,
+  createMCPResponse,
+} from "../../utils/error-handling.js";
+
+export const getSignalsAgentHistoryTool = (client: Scope3ApiClient) => ({
+  annotations: {
+    category: "Signals Agents",
+    dangerLevel: "low",
+    openWorldHint: true,
+    readOnlyHint: true,
+    title: "Get Signals Agent History",
+  },
+
+  description:
+    "View complete activity history for a signals agent including all interactions, segment operations, and performance metrics. Provides audit trail of agent actions. Requires authentication.",
+
+  execute: async (
+    args: GetSignalsAgentHistoryParams,
+    context: MCPToolExecuteContext,
+  ): Promise<string> => {
+    // Check session context first, then fall back to environment variable
+    let apiKey = context.session?.scope3ApiKey;
+
+    if (!apiKey) {
+      apiKey = process.env.SCOPE3_API_KEY;
+    }
+
+    if (!apiKey) {
+      return createAuthErrorResponse();
+    }
+
+    try {
+      // Validate API key
+      const authResult = await client.validateApiKey(apiKey);
+      if (!authResult.isValid) {
+        return createAuthErrorResponse();
+      }
+
+      const signalsAgentService = new SignalsAgentService();
+
+      // Get agent details for context
+      const agent = await signalsAgentService.getSignalsAgent(args.agentId);
+      if (!agent) {
+        return createErrorResponse(
+          `Signals agent ${args.agentId} not found`,
+          null,
+        );
+      }
+
+      const activities = await signalsAgentService.getAgentHistory(
+        args.agentId,
+        args.limit || 50,
+      );
+
+      let summary = `📋 **Signals Agent Activity History**\n\n`;
+      summary += `**Agent:** ${agent.name}\n`;
+      summary += `**Agent ID:** ${args.agentId}\n`;
+      summary += `**Total Activities:** ${activities.length}\n`;
+      summary += `**Query Limit:** ${args.limit || 50}\n`;
+      summary += `**Generated:** ${new Date().toLocaleString()}\n\n`;
+
+      if (activities.length === 0) {
+        summary += `📭 **No Activity Found**\n\n`;
+        summary += `This signals agent has no recorded activity yet.\n\n`;
+        summary += `**Getting Started:**\n`;
+        summary += `• Use \`signals-agent/get-signals\` to query this agent\n`;
+        summary += `• Use \`signals-agent/activate\` to create segments\n`;
+        summary += `• All interactions will be logged here\n`;
+
+        return createMCPResponse({
+          message: summary,
+          success: true,
+        });
+      }
+
+      // Group activities by type for summary
+      const activityTypes = activities.reduce(
+        (acc, activity) => {
+          acc[activity.activityType] = (acc[activity.activityType] || 0) + 1;
+          return acc;
+        },
+        {} as Record<string, number>,
+      );
+
+      const successful = activities.filter(
+        (a) => a.status === "success",
+      ).length;
+      const failed = activities.filter((a) => a.status === "failed").length;
+      const avgResponseTime =
+        activities
+          .filter((a) => a.responseTimeMs)
+          .reduce((sum, a) => sum + (a.responseTimeMs || 0), 0) /
+        activities.length;
+
+      summary += `## 📊 Activity Summary\n\n`;
+      Object.entries(activityTypes).forEach(([type, count]) => {
+        const icon =
+          type === "get_signals"
+            ? "🎯"
+            : type === "activate_signal"
+              ? "🚀"
+              : type.includes("segment")
+                ? "📂"
+                : "📋";
+        summary += `• **${icon} ${type.replace(/_/g, " ")}:** ${count}\n`;
+      });
+      summary += `\n`;
+
+      summary += `**Performance Metrics:**\n`;
+      summary += `• **Success Rate:** ${((successful / activities.length) * 100).toFixed(1)}% (${successful}/${activities.length})\n`;
+      summary += `• **Failed Operations:** ${failed}\n`;
+      if (avgResponseTime > 0) {
+        summary += `• **Avg Response Time:** ${avgResponseTime.toFixed(0)}ms\n`;
+      }
+      summary += `\n`;
+
+      summary += `## 📝 Recent Activities\n\n`;
+
+      activities.forEach((activity, index) => {
+        const statusIcon =
+          activity.status === "success"
+            ? "✅"
+            : activity.status === "failed"
+              ? "❌"
+              : "⏳";
+
+        const typeIcon =
+          activity.activityType === "get_signals"
+            ? "🎯"
+            : activity.activityType === "activate_signal"
+              ? "🚀"
+              : activity.activityType.includes("segment")
+                ? "📂"
+                : "📋";
+
+        summary += `### ${index + 1}. ${typeIcon} ${activity.activityType.replace(/_/g, " ")} ${statusIcon}\n`;
+        summary += `**Time:** ${new Date(activity.executedAt).toLocaleString()}\n`;
+        summary += `**Status:** ${activity.status.toUpperCase()}\n`;
+
+        if (activity.responseTimeMs) {
+          summary += `**Response Time:** ${activity.responseTimeMs}ms\n`;
+        }
+
+        if (activity.request) {
+          summary += `**Request:**\n`;
+          if (activity.request.brief) {
+            summary += `• Brief: "${activity.request.brief}"\n`;
+          }
+          if (activity.request.signalId) {
+            summary += `• Signal ID: ${activity.request.signalId}\n`;
+          }
+          if (activity.request.agentId) {
+            summary += `• Target Agent: ${activity.request.agentId}\n`;
+          }
+        }
+
+        if (activity.segmentIds && activity.segmentIds.length > 0) {
+          summary += `**Affected Segments:** ${activity.segmentIds.length}\n`;
+          if (activity.segmentIds.length <= 3) {
+            activity.segmentIds.forEach((id) => {
+              summary += `• ${id}\n`;
+            });
+          } else {
+            activity.segmentIds.slice(0, 2).forEach((id) => {
+              summary += `• ${id}\n`;
+            });
+            summary += `• ... and ${activity.segmentIds.length - 2} more\n`;
+          }
+        }
+
+        if (activity.response && activity.status === "success") {
+          if (
+            activity.activityType === "get_signals" &&
+            activity.response.signals
+          ) {
+            const signalCount = Array.isArray(activity.response.signals)
+              ? activity.response.signals.length
+              : 0;
+            summary += `**Result:** ${signalCount} signals returned\n`;
+          } else if (
+            activity.activityType === "activate_signal" &&
+            activity.response.segmentId
+          ) {
+            summary += `**Result:** Created segment ${activity.response.segmentId}\n`;
+          }
+        }
+
+        if (activity.errorDetails) {
+          summary += `**Error:** ${activity.errorDetails}\n`;
+        }
+
+        summary += `\n`;
+      });
+
+      // Show trends if we have enough data
+      if (activities.length >= 5) {
+        const recentActivities = activities.slice(0, 10);
+        const recentSuccessRate =
+          (recentActivities.filter((a) => a.status === "success").length /
+            recentActivities.length) *
+          100;
+
+        summary += `## 📈 Recent Trends (Last 10 Activities)\n\n`;
+        summary += `• **Success Rate:** ${recentSuccessRate.toFixed(1)}%\n`;
+
+        const recentAvgTime =
+          recentActivities
+            .filter((a) => a.responseTimeMs)
+            .reduce((sum, a) => sum + (a.responseTimeMs || 0), 0) /
+          recentActivities.length;
+
+        if (recentAvgTime > 0) {
+          summary += `• **Avg Response Time:** ${recentAvgTime.toFixed(0)}ms\n`;
+        }
+        summary += `\n`;
+      }
+
+      summary += `**Available Actions:**\n`;
+      summary += `• Use \`signals-agent/get-signals\` to query this agent again\n`;
+      summary += `• Use \`signals-agent/get\` for detailed agent configuration\n`;
+      summary += `• Use \`signal/list\` to view segments managed by this agent\n`;
+      summary += `• Increase limit parameter to see more history\n`;
+
+      return createMCPResponse({
+        message: summary,
+        success: true,
+      });
+    } catch (error) {
+      return createErrorResponse("Failed to get signals agent history", error);
+    }
+  },
+
+  name: "signals-agent/history",
+  parameters: z.object({
+    agentId: z.string().describe("ID of the signals agent to get history for"),
+    limit: z
+      .number()
+      .optional()
+      .default(50)
+      .describe("Maximum number of activities to return (default: 50)"),
+  }),
+});

--- a/src/tools/signals-agents/list.ts
+++ b/src/tools/signals-agents/list.ts
@@ -1,0 +1,146 @@
+import { z } from "zod";
+
+import type { Scope3ApiClient } from "../../client/scope3-client.js";
+import type {
+  ListSignalsAgentsParams,
+  MCPToolExecuteContext,
+} from "../../types/mcp.js";
+
+import { SignalsAgentService } from "../../services/signals-agent-service.js";
+import {
+  createAuthErrorResponse,
+  createErrorResponse,
+  createMCPResponse,
+} from "../../utils/error-handling.js";
+
+export const listSignalsAgentsTool = (client: Scope3ApiClient) => ({
+  annotations: {
+    category: "Signals Agents",
+    dangerLevel: "low",
+    openWorldHint: true,
+    readOnlyHint: true,
+    title: "List Signals Agents",
+  },
+
+  description:
+    "List all registered signals agents for a brand agent. Shows agent status, endpoints, and registration details. Requires authentication.",
+
+  execute: async (
+    args: ListSignalsAgentsParams,
+    context: MCPToolExecuteContext,
+  ): Promise<string> => {
+    // Check session context first, then fall back to environment variable
+    let apiKey = context.session?.scope3ApiKey;
+
+    if (!apiKey) {
+      apiKey = process.env.SCOPE3_API_KEY;
+    }
+
+    if (!apiKey) {
+      return createAuthErrorResponse();
+    }
+
+    try {
+      // Validate API key
+      const authResult = await client.validateApiKey(apiKey);
+      if (!authResult.isValid) {
+        return createAuthErrorResponse();
+      }
+
+      const signalsAgentService = new SignalsAgentService();
+      const agents = await signalsAgentService.listSignalsAgents(
+        args.brandAgentId,
+      );
+
+      if (agents.length === 0) {
+        let summary = `📭 **No Signals Agents Found**\n\n`;
+        summary += `**Brand Agent:** ${args.brandAgentId}\n\n`;
+        summary += `**Getting Started:**\n`;
+        summary += `• Register your first signals agent with \`signals-agent/register\`\n`;
+        summary += `• Configure your agent to implement the ADCP protocol\n`;
+        summary += `• Start querying agents for signal recommendations\n\n`;
+
+        summary += `**What are Signals Agents?**\n`;
+        summary += `Signals agents are external services that can:\n`;
+        summary += `• Analyze campaign briefs and provide targeting recommendations\n`;
+        summary += `• Create and manage audience segments via our API\n`;
+        summary += `• Optimize campaigns based on their algorithms\n`;
+        summary += `• Integrate with your existing data and systems\n`;
+
+        return createMCPResponse({
+          message: summary,
+          success: true,
+        });
+      }
+
+      let summary = `🤖 **Signals Agents Overview**\n\n`;
+      summary += `**Brand Agent:** ${args.brandAgentId}\n`;
+      summary += `**Total Agents:** ${agents.length}\n\n`;
+
+      // Group by status
+      const activeAgents = agents.filter((a) => a.status === "active");
+      const inactiveAgents = agents.filter((a) => a.status !== "active");
+
+      if (activeAgents.length > 0) {
+        summary += `## 🟢 Active Agents (${activeAgents.length})\n\n`;
+
+        activeAgents.forEach((agent) => {
+          summary += `### ${agent.name}\n`;
+          summary += `• **ID:** ${agent.id}\n`;
+          summary += `• **Endpoint:** ${agent.endpointUrl}\n`;
+          if (agent.description) {
+            summary += `• **Description:** ${agent.description}\n`;
+          }
+          summary += `• **Registered:** ${new Date(agent.registeredAt).toLocaleString()}\n`;
+          if (agent.registeredBy) {
+            summary += `• **Registered by:** ${agent.registeredBy}\n`;
+          }
+          summary += `• **Last Updated:** ${new Date(agent.updatedAt).toLocaleString()}\n`;
+
+          if (agent.config && Object.keys(agent.config).length > 0) {
+            summary += `• **Configuration:** ${Object.keys(agent.config).length} parameter(s)\n`;
+          }
+          summary += `\n`;
+        });
+      }
+
+      if (inactiveAgents.length > 0) {
+        summary += `## ⭕ Inactive/Suspended Agents (${inactiveAgents.length})\n\n`;
+
+        inactiveAgents.forEach((agent) => {
+          summary += `### ${agent.name}\n`;
+          summary += `• **ID:** ${agent.id}\n`;
+          summary += `• **Status:** ${agent.status.toUpperCase()}\n`;
+          summary += `• **Endpoint:** ${agent.endpointUrl}\n`;
+          summary += `• **Registered:** ${new Date(agent.registeredAt).toLocaleString()}\n`;
+          summary += `\n`;
+        });
+      }
+
+      summary += `## 📊 Quick Stats\n\n`;
+      summary += `• **Active:** ${activeAgents.length}\n`;
+      summary += `• **Inactive:** ${inactiveAgents.filter((a) => a.status === "inactive").length}\n`;
+      summary += `• **Suspended:** ${inactiveAgents.filter((a) => a.status === "suspended").length}\n\n`;
+
+      summary += `**Available Actions:**\n`;
+      summary += `• Use \`signals-agent/get\` for detailed agent information\n`;
+      summary += `• Use \`signals-agent/get-signals\` to query agents for recommendations\n`;
+      summary += `• Use \`signals-agent/history\` to view agent activity\n`;
+      summary += `• Use \`signals-agent/update\` to modify agent configuration\n`;
+
+      return createMCPResponse({
+        message: summary,
+        success: true,
+      });
+    } catch (error) {
+      return createErrorResponse("Failed to list signals agents", error);
+    }
+  },
+
+  name: "signals-agent/list",
+  parameters: z.object({
+    brandAgentId: z
+      .string()
+      .describe("ID of the brand agent to list signals agents for"),
+  }),
+});

--- a/src/tools/signals-agents/register.ts
+++ b/src/tools/signals-agents/register.ts
@@ -1,0 +1,133 @@
+import { z } from "zod";
+
+import type { Scope3ApiClient } from "../../client/scope3-client.js";
+import type {
+  MCPToolExecuteContext,
+  RegisterSignalsAgentParams,
+} from "../../types/mcp.js";
+
+import { SignalsAgentService } from "../../services/signals-agent-service.js";
+import {
+  createAuthErrorResponse,
+  createErrorResponse,
+  createMCPResponse,
+} from "../../utils/error-handling.js";
+
+export const registerSignalsAgentTool = (client: Scope3ApiClient) => ({
+  annotations: {
+    category: "Signals Agents",
+    dangerLevel: "low",
+    openWorldHint: true,
+    readOnlyHint: false,
+    title: "Register Signals Agent",
+  },
+
+  description:
+    "Register a new signals agent to your seat. The agent will receive permissions to manage segments in your account using our API. Supports ADCP (Advertising Data Control Protocol) compliant agents. Requires authentication.",
+
+  execute: async (
+    args: RegisterSignalsAgentParams,
+    context: MCPToolExecuteContext,
+  ): Promise<string> => {
+    // Check session context first, then fall back to environment variable
+    let apiKey = context.session?.scope3ApiKey;
+
+    if (!apiKey) {
+      apiKey = process.env.SCOPE3_API_KEY;
+    }
+
+    if (!apiKey) {
+      return createAuthErrorResponse();
+    }
+
+    try {
+      // Get customer ID from auth service
+      const authResult = await client.validateApiKey(apiKey);
+      if (!authResult.isValid || !authResult.customerId) {
+        return createAuthErrorResponse();
+      }
+
+      const signalsAgentService = new SignalsAgentService();
+      const agent = await signalsAgentService.registerSignalsAgent(
+        {
+          brandAgentId: args.brandAgentId,
+          config: args.config,
+          description: args.description,
+          endpointUrl: args.endpointUrl,
+          name: args.name,
+          registeredBy: authResult.customerId.toString(),
+        },
+        authResult.customerId,
+      );
+
+      let summary = `✅ Signals Agent Registered Successfully!\n\n`;
+      summary += `**Agent Details:**\n`;
+      summary += `• **ID:** ${agent.id}\n`;
+      summary += `• **Name:** ${agent.name}\n`;
+      summary += `• **Endpoint:** ${agent.endpointUrl}\n`;
+      if (agent.description) {
+        summary += `• **Description:** ${agent.description}\n`;
+      }
+      summary += `• **Brand Agent:** ${agent.brandAgentId}\n`;
+      summary += `• **Status:** ${agent.status}\n`;
+      summary += `• **Registered:** ${new Date(agent.registeredAt).toLocaleString()}\n\n`;
+
+      summary += `**🔑 Agent Permissions:**\n`;
+      summary += `This agent is now authorized to:\n`;
+      summary += `• Create new segments using our API\n`;
+      summary += `• Update segments it has created\n`;
+      summary += `• Delete segments it manages\n`;
+      summary += `• View segments it has access to\n\n`;
+
+      summary += `**📡 ADCP Protocol:**\n`;
+      summary += `Your agent should implement the Advertising Data Control Protocol (ADCP) with these endpoints:\n`;
+      summary += `• \`POST ${agent.endpointUrl}\` - Receive get_signals and activate_signal requests\n`;
+      summary += `• Response format: \`{"status": "success", "data": {...}, "requestId": "..."}\`\n\n`;
+
+      summary += `**Next Steps:**\n`;
+      summary += `• Use \`signals-agent/get-signals\` to query this agent for recommendations\n`;
+      summary += `• Use \`signals-agent/activate\` to tell the agent to create segments\n`;
+      summary += `• Monitor agent activity with \`signals-agent/history\`\n`;
+      summary += `• Configure your agent to call our API endpoints for segment management\n\n`;
+
+      summary += `**Integration Example:**\n`;
+      summary += `\`\`\`javascript\n`;
+      summary += `// Query agent for signals\n`;
+      summary += `const signals = await getSignals("${agent.id}", "Target millennials interested in sustainable fashion");\n\n`;
+      summary += `// Activate a recommended signal\n`;
+      summary += `const segmentId = await activateSignal("${agent.id}", "recommended_signal_id");\n`;
+      summary += `\`\`\`\n\n`;
+
+      summary += `The signals agent is ready to manage segments in your account!`;
+
+      return createMCPResponse({
+        message: summary,
+        success: true,
+      });
+    } catch (error) {
+      return createErrorResponse("Failed to register signals agent", error);
+    }
+  },
+
+  name: "signals-agent/register",
+  parameters: z.object({
+    brandAgentId: z
+      .string()
+      .describe("ID of the brand agent this signals agent will work with"),
+    config: z
+      .record(z.unknown())
+      .optional()
+      .describe("Optional configuration parameters for the agent"),
+    description: z
+      .string()
+      .optional()
+      .describe("Optional description of what this agent does"),
+    endpointUrl: z
+      .string()
+      .url()
+      .describe(
+        "ADCP-compliant endpoint URL where the agent receives requests",
+      ),
+    name: z.string().describe("Human-readable name for the signals agent"),
+  }),
+});

--- a/src/tools/signals-agents/unregister.ts
+++ b/src/tools/signals-agents/unregister.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+
+import type { Scope3ApiClient } from "../../client/scope3-client.js";
+import type {
+  MCPToolExecuteContext,
+  UnregisterSignalsAgentParams,
+} from "../../types/mcp.js";
+
+import { SignalsAgentService } from "../../services/signals-agent-service.js";
+import {
+  createAuthErrorResponse,
+  createErrorResponse,
+  createMCPResponse,
+} from "../../utils/error-handling.js";
+
+export const unregisterSignalsAgentTool = (client: Scope3ApiClient) => ({
+  annotations: {
+    category: "Signals Agents",
+    dangerLevel: "high",
+    openWorldHint: true,
+    readOnlyHint: false,
+    title: "Unregister Signals Agent",
+  },
+
+  description:
+    "Unregister a signals agent from your seat. This revokes the agent's API access and sets its status to inactive. The agent will no longer be able to manage segments. Requires authentication.",
+
+  execute: async (
+    args: UnregisterSignalsAgentParams,
+    context: MCPToolExecuteContext,
+  ): Promise<string> => {
+    // Check session context first, then fall back to environment variable
+    let apiKey = context.session?.scope3ApiKey;
+
+    if (!apiKey) {
+      apiKey = process.env.SCOPE3_API_KEY;
+    }
+
+    if (!apiKey) {
+      return createAuthErrorResponse();
+    }
+
+    try {
+      // Validate API key
+      const authResult = await client.validateApiKey(apiKey);
+      if (!authResult.isValid) {
+        return createAuthErrorResponse();
+      }
+
+      const signalsAgentService = new SignalsAgentService();
+
+      // Get agent details before unregistering for better reporting
+      const agent = await signalsAgentService.getSignalsAgent(args.agentId);
+      if (!agent) {
+        return createErrorResponse(
+          `Signals agent ${args.agentId} not found`,
+          null,
+        );
+      }
+
+      await signalsAgentService.unregisterSignalsAgent(args.agentId);
+
+      let summary = `✅ Signals Agent Unregistered Successfully!\n\n`;
+      summary += `**Unregistered Agent:**\n`;
+      summary += `• **Name:** ${agent.name}\n`;
+      summary += `• **ID:** ${args.agentId}\n`;
+      summary += `• **Brand Agent:** ${agent.brandAgentId}\n`;
+      summary += `• **Previous Status:** ${agent.status}\n`;
+      summary += `• **Unregistered:** ${new Date().toLocaleString()}\n\n`;
+
+      summary += `**🔒 Access Revoked:**\n`;
+      summary += `This signals agent no longer has:\n`;
+      summary += `• Permission to create new segments\n`;
+      summary += `• Permission to update existing segments\n`;
+      summary += `• Permission to delete segments it created\n`;
+      summary += `• API access to your account\n\n`;
+
+      summary += `**📂 Existing Segments:**\n`;
+      summary += `• Segments previously created by this agent remain in your account\n`;
+      summary += `• These segments are no longer managed by the agent\n`;
+      summary += `• You can view them with \`signal/list\`\n`;
+      summary += `• You can manually manage them via standard signal tools\n\n`;
+
+      summary += `**📋 Activity History:**\n`;
+      summary += `• All activity history has been preserved\n`;
+      summary += `• Use \`signals-agent/history ${args.agentId}\` to view past interactions\n`;
+      summary += `• Audit trail remains available for compliance\n\n`;
+
+      summary += `**⚠️ Important Notes:**\n`;
+      summary += `• The agent service will receive HTTP errors when attempting API calls\n`;
+      summary += `• Any ongoing operations by the agent will be denied\n`;
+      summary += `• Re-registration requires using \`signals-agent/register\` again\n`;
+      summary += `• The agent ID will remain the same if re-registered\n\n`;
+
+      summary += `**Next Steps:**\n`;
+      summary += `• Review segments created by this agent: \`signal/list\`\n`;
+      summary += `• Update campaigns that may have used agent-created segments\n`;
+      summary += `• Inform the agent operator about the deregistration\n`;
+      summary += `• Consider registering alternative agents if needed\n\n`;
+
+      summary += `**Re-registration:**\n`;
+      summary += `If you need this agent again:\n`;
+      summary += `\`\`\`bash\n`;
+      summary += `signals-agent/register ${agent.brandAgentId} "${agent.name}" ${agent.endpointUrl}\n`;
+      summary += `\`\`\`\n\n`;
+
+      summary += `The signals agent has been successfully unregistered and access has been revoked.`;
+
+      return createMCPResponse({
+        message: summary,
+        success: true,
+      });
+    } catch (error) {
+      return createErrorResponse("Failed to unregister signals agent", error);
+    }
+  },
+
+  name: "signals-agent/unregister",
+  parameters: z.object({
+    agentId: z.string().describe("ID of the signals agent to unregister"),
+  }),
+});

--- a/src/tools/signals-agents/update.ts
+++ b/src/tools/signals-agents/update.ts
@@ -1,0 +1,214 @@
+import { z } from "zod";
+
+import type { Scope3ApiClient } from "../../client/scope3-client.js";
+import type {
+  MCPToolExecuteContext,
+  UpdateSignalsAgentParams,
+} from "../../types/mcp.js";
+
+import { SignalsAgentService } from "../../services/signals-agent-service.js";
+import {
+  createAuthErrorResponse,
+  createErrorResponse,
+  createMCPResponse,
+} from "../../utils/error-handling.js";
+
+export const updateSignalsAgentTool = (client: Scope3ApiClient) => ({
+  annotations: {
+    category: "Signals Agents",
+    dangerLevel: "medium",
+    openWorldHint: true,
+    readOnlyHint: false,
+    title: "Update Signals Agent",
+  },
+
+  description:
+    "Update configuration and settings for a registered signals agent. Can modify name, description, endpoint, status, and configuration parameters. Requires authentication.",
+
+  execute: async (
+    args: UpdateSignalsAgentParams,
+    context: MCPToolExecuteContext,
+  ): Promise<string> => {
+    // Check session context first, then fall back to environment variable
+    let apiKey = context.session?.scope3ApiKey;
+
+    if (!apiKey) {
+      apiKey = process.env.SCOPE3_API_KEY;
+    }
+
+    if (!apiKey) {
+      return createAuthErrorResponse();
+    }
+
+    try {
+      // Validate API key
+      const authResult = await client.validateApiKey(apiKey);
+      if (!authResult.isValid) {
+        return createAuthErrorResponse();
+      }
+
+      const signalsAgentService = new SignalsAgentService();
+
+      // Get current agent state for comparison
+      const currentAgent = await signalsAgentService.getSignalsAgent(
+        args.agentId,
+      );
+      if (!currentAgent) {
+        return createErrorResponse(
+          `Signals agent ${args.agentId} not found`,
+          null,
+        );
+      }
+
+      const updatedAgent = await signalsAgentService.updateSignalsAgent(
+        args.agentId,
+        {
+          config: args.config,
+          description: args.description,
+          endpointUrl: args.endpointUrl,
+          name: args.name,
+          status: args.status,
+        },
+      );
+
+      let summary = `✅ Signals Agent Updated Successfully!\n\n`;
+      summary += `**Agent:** ${updatedAgent.name}\n`;
+      summary += `**Agent ID:** ${args.agentId}\n`;
+      summary += `**Updated:** ${new Date().toLocaleString()}\n\n`;
+
+      // Show what changed
+      const changes: string[] = [];
+
+      if (args.name && args.name !== currentAgent.name) {
+        changes.push(`**Name:** "${currentAgent.name}" → "${args.name}"`);
+      }
+
+      if (
+        args.description !== undefined &&
+        args.description !== currentAgent.description
+      ) {
+        const oldDesc = currentAgent.description || "(none)";
+        const newDesc = args.description || "(none)";
+        changes.push(`**Description:** "${oldDesc}" → "${newDesc}"`);
+      }
+
+      if (args.endpointUrl && args.endpointUrl !== currentAgent.endpointUrl) {
+        changes.push(
+          `**Endpoint:** "${currentAgent.endpointUrl}" → "${args.endpointUrl}"`,
+        );
+      }
+
+      if (args.status && args.status !== currentAgent.status) {
+        changes.push(`**Status:** ${currentAgent.status} → ${args.status}`);
+      }
+
+      if (args.config) {
+        changes.push(
+          `**Configuration:** Updated with ${Object.keys(args.config).length} parameter(s)`,
+        );
+      }
+
+      if (changes.length > 0) {
+        summary += `**Changes Made:**\n`;
+        changes.forEach((change) => {
+          summary += `• ${change}\n`;
+        });
+        summary += `\n`;
+      } else {
+        summary += `**No Changes:** All provided values were the same as existing values.\n\n`;
+      }
+
+      summary += `**Current Configuration:**\n`;
+      summary += `• **Name:** ${updatedAgent.name}\n`;
+      summary += `• **Status:** ${updatedAgent.status.toUpperCase()}\n`;
+      summary += `• **Endpoint:** ${updatedAgent.endpointUrl}\n`;
+      summary += `• **Brand Agent:** ${updatedAgent.brandAgentId}\n`;
+
+      if (updatedAgent.description) {
+        summary += `• **Description:** ${updatedAgent.description}\n`;
+      }
+
+      if (updatedAgent.config && Object.keys(updatedAgent.config).length > 0) {
+        summary += `• **Config Parameters:** ${Object.keys(updatedAgent.config).length}\n`;
+      }
+      summary += `\n`;
+
+      // Status-specific information
+      if (args.status) {
+        summary += `**Status Impact:**\n`;
+        switch (args.status) {
+          case "active":
+            summary += `• ✅ Agent is now active and can process requests\n`;
+            summary += `• Can receive get-signals and activate-signal requests\n`;
+            summary += `• Authorized to manage segments via API\n`;
+            break;
+          case "inactive":
+            summary += `• ⭕ Agent is now inactive and will not process requests\n`;
+            summary += `• Cannot create or manage segments\n`;
+            summary += `• Existing segments remain unaffected\n`;
+            break;
+          case "suspended":
+            summary += `• ⛔ Agent is now suspended\n`;
+            summary += `• All API access has been revoked\n`;
+            summary += `• Cannot process any requests\n`;
+            break;
+        }
+        summary += `\n`;
+      }
+
+      if (args.endpointUrl) {
+        summary += `**⚠️ Endpoint Change:**\n`;
+        summary += `• Make sure your agent service is running at the new endpoint\n`;
+        summary += `• Test connectivity with \`signals-agent/get-signals\`\n`;
+        summary += `• Update any monitoring or alerting for the new URL\n\n`;
+      }
+
+      summary += `**Verification:**\n`;
+      summary += `• Use \`signals-agent/get\` to verify all changes\n`;
+      if (updatedAgent.status === "active") {
+        summary += `• Use \`signals-agent/get-signals\` to test agent connectivity\n`;
+      }
+      summary += `• Use \`signals-agent/history\` to monitor agent activity\n\n`;
+
+      if (updatedAgent.config && Object.keys(updatedAgent.config).length > 0) {
+        summary += `**Configuration Details:**\n`;
+        Object.entries(updatedAgent.config).forEach(([key, value]) => {
+          summary += `• **${key}:** ${JSON.stringify(value)}\n`;
+        });
+        summary += `\n`;
+      }
+
+      summary += `The signals agent configuration has been successfully updated!`;
+
+      return createMCPResponse({
+        message: summary,
+        success: true,
+      });
+    } catch (error) {
+      return createErrorResponse("Failed to update signals agent", error);
+    }
+  },
+
+  name: "signals-agent/update",
+  parameters: z.object({
+    agentId: z.string().describe("ID of the signals agent to update"),
+    config: z
+      .record(z.unknown())
+      .optional()
+      .describe("Optional configuration parameters to update"),
+    description: z
+      .string()
+      .optional()
+      .describe("Optional new description for the agent"),
+    endpointUrl: z
+      .string()
+      .url()
+      .optional()
+      .describe("Optional new ADCP endpoint URL"),
+    name: z.string().optional().describe("Optional new name for the agent"),
+    status: z
+      .enum(["active", "inactive", "suspended"])
+      .optional()
+      .describe("Optional new status for the agent"),
+  }),
+});

--- a/src/tools/signals/get-partner-seats.ts
+++ b/src/tools/signals/get-partner-seats.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+import type { Scope3ApiClient } from "../../client/scope3-client.js";
+import type { MCPToolExecuteContext } from "../../types/mcp.js";
+
+import { CustomSignalsClient } from "../../services/custom-signals-client.js";
+import {
+  createAuthErrorResponse,
+  createErrorResponse,
+  createMCPResponse,
+} from "../../utils/error-handling.js";
+
+export const getPartnerSeatsTool = (client: Scope3ApiClient) => ({
+  annotations: {
+    category: "Signals",
+    dangerLevel: "low",
+    readOnlyHint: true,
+    title: "Get Partner Seats",
+  },
+  description: "Get brand agent seats (advertisers) accessible to your API key",
+  execute: async (
+    params: Record<string, never>,
+    context: MCPToolExecuteContext,
+  ): Promise<string> => {
+    // Check session context first, then fall back to environment variable
+    let apiKey = context.session?.scope3ApiKey;
+
+    if (!apiKey) {
+      apiKey = process.env.SCOPE3_API_KEY;
+    }
+
+    if (!apiKey) {
+      return createAuthErrorResponse();
+    }
+
+    try {
+      const customSignalsClient = new CustomSignalsClient();
+      const seats = await customSignalsClient.getPartnerSeats(client, apiKey);
+
+      const summary = `Found ${seats.length} accessible brand agent seats`;
+      const details = seats
+        .map(
+          (seat) =>
+            `• **${seat.name}** (${seat.id}) - Customer ID: ${seat.customerId}`,
+        )
+        .join("\n");
+
+      let message = `📊 **Partner Seats Overview**\n\n`;
+      message += `**${summary}**\n\n`;
+      if (seats.length > 0) {
+        message += `**Accessible Seats:**\n${details}\n\n`;
+        message += `Use \`signals/get-seat-segments\` to view segments deployed on specific seats.`;
+      } else {
+        message += `No brand agent seats are accessible with your API key.`;
+      }
+
+      return createMCPResponse({
+        message,
+        success: true,
+      });
+    } catch (error) {
+      return createErrorResponse("Failed to get partner seats", error);
+    }
+  },
+  name: "signals/get-partner-seats",
+  parameters: z.object({}),
+});

--- a/src/tools/signals/list.ts
+++ b/src/tools/signals/list.ts
@@ -134,7 +134,10 @@ export const listCustomSignalsTool = (client: Scope3ApiClient) => ({
 
           // Show seat information if available
           if ((signal as Record<string, unknown>)._seatInfo) {
-            const seatInfo = (signal as Record<string, unknown>)._seatInfo as { seatName: string; seatId: string };
+            const seatInfo = (signal as Record<string, unknown>)._seatInfo as {
+              seatName: string;
+              seatId: string;
+            };
             summary += `• **Seat:** ${seatInfo.seatName} (${seatInfo.seatId})\n`;
           }
 

--- a/src/tools/signals/list.ts
+++ b/src/tools/signals/list.ts
@@ -134,7 +134,7 @@ export const listCustomSignalsTool = (client: Scope3ApiClient) => ({
 
           // Show seat information if available
           if ((signal as Record<string, unknown>)._seatInfo) {
-            const seatInfo = (signal as Record<string, unknown>)._seatInfo;
+            const seatInfo = (signal as Record<string, unknown>)._seatInfo as { seatName: string; seatId: string };
             summary += `• **Seat:** ${seatInfo.seatName} (${seatInfo.seatId})\n`;
           }
 

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -1,5 +1,11 @@
 // import type { AuthContext } from "./auth.js";
 
+// Signals Agent MCP parameter types
+export interface ActivateSignalParams {
+  agentId: string;
+  signalId: string;
+}
+
 // Measurement Source MCP parameter types (stub)
 export interface AddMeasurementSourceParams {
   brandAgentId: string;
@@ -81,8 +87,6 @@ export interface CreateCampaignParams {
   startDate?: string;
 }
 
-// Tool parameter interfaces (legacy - remove if unused)
-
 // Custom Signal Definition MCP parameter types
 export interface CreateCustomSignalParams {
   clusters: Array<{
@@ -140,6 +144,8 @@ export interface ExportCampaignDataParams {
   >;
 }
 
+// Tool parameter interfaces (legacy - remove if unused)
+
 // FastMCP types compatibility
 export interface FastMCPSessionAuth extends Record<string, unknown> {
   customerId?: number;
@@ -164,6 +170,21 @@ export interface GetCampaignSummaryParams {
 
 export interface GetCustomSignalParams {
   signalId: string;
+}
+
+export interface GetSignalsAgentHistoryParams {
+  agentId: string;
+  limit?: number;
+}
+
+export interface GetSignalsAgentParams {
+  agentId: string;
+}
+
+export interface GetSignalsParams {
+  agentIds?: string[];
+  brandAgentId: string;
+  brief?: string;
 }
 
 export interface ListBrandAgentCampaignsParams {
@@ -195,9 +216,14 @@ export interface ListBrandAgentStoriesParams {
 export interface ListCustomSignalsParams {
   channel?: string;
   region?: string;
+  seatId?: string;
 }
 
 export interface ListMeasurementSourcesParams {
+  brandAgentId: string;
+}
+
+export interface ListSignalsAgentsParams {
   brandAgentId: string;
 }
 
@@ -232,6 +258,14 @@ export interface ProvideScoringOutcomesParams {
   tacticId?: string;
 }
 
+export interface RegisterSignalsAgentParams {
+  brandAgentId: string;
+  config?: Record<string, unknown>;
+  description?: string;
+  endpointUrl: string;
+  name: string;
+}
+
 export interface RegisterWebhookParams {
   brandAgentId: string;
   endpoint: {
@@ -263,6 +297,10 @@ export interface ToolResponse {
   errorCode?: string;
   message: string;
   success: boolean;
+}
+
+export interface UnregisterSignalsAgentParams {
+  agentId: string;
 }
 
 // Legacy interface - use UpdateCampaignParams instead
@@ -344,6 +382,15 @@ export interface UpdateMeasurementSourceParams {
   sourceId: string;
   status?: "active" | "error" | "inactive";
   type?: "analytics" | "brand_study" | "conversion_api" | "mmm";
+}
+
+export interface UpdateSignalsAgentParams {
+  agentId: string;
+  config?: Record<string, unknown>;
+  description?: string;
+  endpointUrl?: string;
+  name?: string;
+  status?: "active" | "inactive" | "suspended";
 }
 
 export interface UpdateSyntheticAudienceParams {

--- a/src/types/signals-agent.ts
+++ b/src/types/signals-agent.ts
@@ -1,0 +1,119 @@
+// Signals Agent types - represents external agents that manage segments
+
+// Activate signal request
+export interface ActivateSignalRequest {
+  signalId: string; // ID from agent's get_signals response
+}
+
+export interface ActivateSignalResponse {
+  segmentId: string;
+  segmentIds?: string[]; // If agent created multiple segments
+}
+
+// ADCP protocol types for communication with agents
+export interface ADCPRequest {
+  action: "activate_signal" | "get_signals";
+  data?: Record<string, unknown>;
+  requestId: string;
+  timestamp: string;
+}
+
+export interface ADCPResponse {
+  data?: Record<string, unknown>;
+  error?: {
+    code: string;
+    message: string;
+  };
+  requestId: string;
+  status: "error" | "success";
+  timestamp: string;
+}
+
+// Get signals request/response types
+export interface GetSignalsRequest {
+  brief?: string; // Optional campaign brief for tailored signals
+  context?: {
+    brandAgentId: string;
+    campaignId?: string;
+    objectives?: string[];
+  };
+}
+
+export interface GetSignalsResponse {
+  agentId: string;
+  agentName: string;
+  metadata?: Record<string, unknown>;
+  signals: Array<{
+    clusters: Array<{
+      channel?: string;
+      gdpr?: boolean;
+      region: string;
+    }>;
+    confidence?: number;
+    description: string;
+    id?: string; // If referencing existing segment
+    keyType: string;
+    name: string;
+    reasoning?: string;
+  }>;
+}
+
+export interface SignalsAgent {
+  brandAgentId: string;
+  config?: Record<string, unknown>;
+  createdAt: Date;
+  description?: string;
+  endpointUrl: string;
+  id: string;
+  name: string;
+  registeredAt: Date;
+  registeredBy?: string;
+  status: "active" | "inactive" | "suspended";
+  updatedAt: Date;
+}
+
+export interface SignalsAgentActivitiesData {
+  activities: SignalsAgentActivity[];
+  total: number;
+}
+
+// Agent activity tracking
+export interface SignalsAgentActivity {
+  activityType:
+    | "activate_signal"
+    | "get_signals"
+    | "segment_created"
+    | "segment_deleted"
+    | "segment_updated";
+  brandAgentId: string;
+  errorDetails?: string;
+  executedAt: Date;
+  id: string;
+  request?: Record<string, unknown>;
+  response?: Record<string, unknown>;
+  responseTimeMs?: number;
+  segmentIds?: string[];
+  signalsAgentId: string;
+  status: "failed" | "success" | "timeout";
+}
+
+export interface SignalsAgentInput {
+  brandAgentId: string;
+  config?: Record<string, unknown>;
+  description?: string;
+  endpointUrl: string;
+  name: string;
+  registeredBy?: string;
+}
+
+export interface SignalsAgentsData {
+  signalsAgents: SignalsAgent[];
+}
+
+export interface SignalsAgentUpdateInput {
+  config?: Record<string, unknown>;
+  description?: string;
+  endpointUrl?: string;
+  name?: string;
+  status?: "active" | "inactive" | "suspended";
+}


### PR DESCRIPTION
## Summary

- Update region names to new standard: `americas`, `emea-ex-eu`, `eu`, `apac-ex-china`, `china`
- Move partner authentication to dedicated Getting Started section for broader use across agent integrations
- Fix signals agent registration to be seat-level (no `brandAgentId` required)  
- Add comprehensive signals agent field documentation
- Update targeting keys with accurate list from Scope3 docs (removed unsupported `email_hash`, `phone_hash`)
- Remove unsupported features from docs (parquet files, identity graphs)
- Update API key acquisition link to direct Scope3 portal

## Documentation Structure Changes

**New Partner Navigation:**
```
For Partners
├── Getting Started 
│   └── Partner Authentication (moved from Signals Management)
├── Publisher Integration
│   ├── Publisher Setup
│   ├── Sales Agents
│   └── Axe Integration  
└── Signals Management
    ├── Segment Management
    └── Data Attachment
```

## Technical Changes

- Fixed TypeScript compilation issues with `validateApiKey` method
- Updated MCP tool syntax to use proper JSON format throughout
- Enhanced partner seat discovery with `signals/get-partner-seats` tool
- Removed manual GDPR flags (now automatic)
- Added complete targeting key taxonomy from dimension weights API

## Test Plan

- [ ] Documentation builds successfully with Mintlify
- [ ] All MCP tools compile and validate
- [ ] OpenAPI specification generates correctly  
- [ ] Partner authentication flow works end-to-end
- [ ] New region names work in all targeting examples

🤖 Generated with [Claude Code](https://claude.ai/code)