### PR TITLE
docs: Add 'Designing Ad Products' to navigation and publisher setup flow

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -88,6 +88,7 @@
             "group": "Publisher Integration",
             "pages": [
               "mintlify/partners/publisher-setup",
+              "mintlify/partners/designing-ad-products",
               "mintlify/partners/publisher-prebid-setup",
               "mintlify/partners/sales-agents",
               "mintlify/partners/axe-integration"

--- a/mintlify/partners/publisher-setup.mdx
+++ b/mintlify/partners/publisher-setup.mdx
@@ -91,6 +91,16 @@ Whether you need to integrate AXE depends on your sales agent choice:
 
 **👉 If your sales agent requires additional AXE setup, see the [AXE Integration guide](/mintlify/partners/axe-integration).**
 
+## Next Steps: Optimize Your Ad Products
+
+Once your technical integration is complete, the key to success is structuring your inventory as discoverable products that buying agents can understand and test.
+
+**👉 See [Designing Ad Products](/mintlify/partners/designing-ad-products)** to learn how to:
+- Package inventory into testable products
+- Write descriptions that AI agents can understand
+- Set pricing strategies that maximize revenue
+- Support consistent daily spend requirements
+
 ## Frequently Asked Questions
 
 **Q: How long does publisher integration typically take?**


### PR DESCRIPTION
## Summary
- Add "Designing Ad Products" documentation to Publisher Integration section in sidebar navigation
- Link to ad products guide from publisher setup as logical next step after technical integration
- Creates clear flow: technical setup → product optimization

## Changes
- `docs.json`: Added `designing-ad-products` to Publisher Integration navigation group
- `publisher-setup.mdx`: Added "Next Steps" section linking to ad products guide with clear benefits

## Context
The "Designing Ad Products" documentation was created but not discoverable in the navigation or referenced in the publisher onboarding flow. This creates a better user journey for publishers setting up with Scope3.

🤖 Generated with [Claude Code](https://claude.ai/code)