### PR TITLE
docs: Fix navigation icons and remove duplicate content

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -28,7 +28,8 @@
             ]
           },
           {
-            "group": "🌟 Features",
+            "group": "Features",
+            "icon": "star",
             "pages": [
               "mintlify/features/media-quality",
               "mintlify/features/publisher-integration",
@@ -36,7 +37,8 @@
             ]
           },
           {
-            "group": "📦 Object Guides",
+            "group": "Object Guides",
+            "icon": "cube",
             "pages": [
               "mintlify/object-guides/brand-agent",
               "mintlify/object-guides/campaign",
@@ -50,7 +52,8 @@
             ]
           },
           {
-            "group": "🔧 Optimization",
+            "group": "Optimization",
+            "icon": "wrench",
             "pages": [
               "mintlify/optimization/scoring",
               "mintlify/optimization/scope3-algorithms",
@@ -58,7 +61,8 @@
             ]
           },
           {
-            "group": "🔌 Integrations",
+            "group": "Integrations",
+            "icon": "plug",
             "pages": [
               "mintlify/integrations/webhooks",
               "mintlify/integrations/creative-agents",
@@ -66,7 +70,8 @@
             ]
           },
           {
-            "group": "📊 Reporting & Analytics",
+            "group": "Reporting & Analytics",
+            "icon": "chart-bar",
             "pages": ["mintlify/reporting-overview"]
           }
         ]

--- a/mintlify/partners/designing-ad-products.mdx
+++ b/mintlify/partners/designing-ad-products.mdx
@@ -4,8 +4,6 @@ description: "How to structure ad products to maximize spend from Scope3 buying 
 icon: "package"
 ---
 
-# Designing Ad Products for Scope3 Buying Agents
-
 ## The Fundamental Shift: From Impressions to Discoverable Products
 
 In the Scope3 ecosystem, buyers (through their agents) don't evaluate individual impressions—they discover and test products that match their audience needs and campaign goals. This requires publishers to think differently about packaging inventory.

--- a/mintlify/partners/publisher-prebid-setup.mdx
+++ b/mintlify/partners/publisher-prebid-setup.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Scope3-hosted for GAM + Prebid"
 description: "Complete guide to setting up a publisher using the Scope3-hosted GAM sales agent"
-icon: "handshake"
+icon: "server"
 ---
 
 # Publisher Setup with Hosted Sales Agent

--- a/mintlify/partners/sales-agents.mdx
+++ b/mintlify/partners/sales-agents.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Sales Agents"
 description: "Choose your sales agent for Scope3 agentic advertising integration"
-icon: "handshake"
+icon: "user-tie"
 ---
 
 # Agentic Sales Platforms


### PR DESCRIPTION
## Summary

- Replace emoji text labels with proper Mintlify icons in navigation groups
- Remove duplicative page heading from "Designing Ad Products" 
- Fix icon conflicts between partner pages with distinct, semantic icons

## Changes

### Navigation Icons
- **Features**: Added `star` icon (replacing 🌟 emoji)
- **Object Guides**: Added `cube` icon (replacing 📦 emoji)  
- **Optimization**: Added `wrench` icon (replacing 🔧 emoji)
- **Integrations**: Added `plug` icon (replacing 🔌 emoji)
- **Reporting & Analytics**: Added `chart-bar` icon (replacing 📊 emoji)

### Content Fixes
- **"Designing Ad Products"**: Removed duplicate H1 heading (title already in frontmatter)
- **"Sales Agents"**: Changed icon from `handshake` to `user-tie` 
- **"Scope3-hosted for GAM + Prebid"**: Changed icon from `handshake` to `server`

## Test Plan

- [x] Local docs build succeeds
- [x] All linting and type checks pass
- [x] Navigation displays proper icons instead of emoji text
- [x] Page content no longer has duplicate headings
- [x] Partner pages have distinct, semantic icons

🤖 Generated with [Claude Code](https://claude.ai/code)