### PR TITLE
Remove external table dependencies and add customer_id columns

### DIFF
--- a/scripts/create-bigquery-tables.sql
+++ b/scripts/create-bigquery-tables.sql
@@ -22,6 +22,7 @@ CLUSTER BY agent_id;
 CREATE TABLE IF NOT EXISTS `bok-playground.agenticapi.campaigns` (
   id STRING NOT NULL,
   brand_agent_id INT64 NOT NULL,
+  customer_id INT64 NOT NULL,
   name STRING NOT NULL,
   prompt STRING,
   status STRING DEFAULT 'draft',
@@ -37,12 +38,13 @@ CREATE TABLE IF NOT EXISTS `bok-playground.agenticapi.campaigns` (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP()
 )
 PARTITION BY DATE(created_at)
-CLUSTER BY brand_agent_id, status;
+CLUSTER BY brand_agent_id, customer_id, status;
 
 -- 3. Creatives
 CREATE TABLE IF NOT EXISTS `bok-playground.agenticapi.creatives` (
   id STRING NOT NULL,
   brand_agent_id INT64 NOT NULL,
+  customer_id INT64 NOT NULL,
   name STRING NOT NULL,
   description STRING,
   format_type STRING,
@@ -58,7 +60,7 @@ CREATE TABLE IF NOT EXISTS `bok-playground.agenticapi.creatives` (
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP()
 )
 PARTITION BY DATE(created_at)
-CLUSTER BY brand_agent_id, status;
+CLUSTER BY brand_agent_id, customer_id, status;
 
 -- 4. Campaign-Creative Assignment Mapping
 CREATE TABLE IF NOT EXISTS `bok-playground.agenticapi.campaign_creatives` (
@@ -118,6 +120,17 @@ CREATE TABLE IF NOT EXISTS `bok-playground.agenticapi.signals_agent_activity` (
 )
 PARTITION BY DATE(executed_at)
 CLUSTER BY signals_agent_id, activity_type;
+
+-- Migration: Add customer_id columns to existing tables
+-- Run these if the tables already exist without the new columns:
+
+-- Add customer_id to campaigns table
+ALTER TABLE `bok-playground.agenticapi.campaigns`
+ADD COLUMN IF NOT EXISTS customer_id INT64 DEFAULT 1;
+
+-- Add customer_id to creatives table  
+ALTER TABLE `bok-playground.agenticapi.creatives`
+ADD COLUMN IF NOT EXISTS customer_id INT64 DEFAULT 1;
 
 -- Migration: Add tactic_seed_data_coop column to existing brand_agent_extensions table
 -- Run this if the table already exists without the new column:

--- a/src/client/scope3-client.ts
+++ b/src/client/scope3-client.ts
@@ -489,18 +489,21 @@ export class Scope3ApiClient {
   ): Promise<BrandAgentCampaign> {
     try {
       // Create campaign in BigQuery
-      const campaignId = await this.campaignService.createCampaign({
-        brandAgentId: input.brandAgentId,
-        budgetCurrency: input.budget?.currency,
-        budgetDailyCap: input.budget?.dailyCap,
-        budgetPacing: input.budget?.pacing,
-        budgetTotal: input.budget?.total,
-        endDate: input.endDate,
-        name: input.name,
-        prompt: input.prompt,
-        startDate: input.startDate,
-        status: "draft", // Always start as draft
-      });
+      const campaignId = await this.campaignService.createCampaign(
+        {
+          brandAgentId: input.brandAgentId,
+          budgetCurrency: input.budget?.currency,
+          budgetDailyCap: input.budget?.dailyCap,
+          budgetPacing: input.budget?.pacing,
+          budgetTotal: input.budget?.total,
+          endDate: input.endDate,
+          name: input.name,
+          prompt: input.prompt,
+          startDate: input.startDate,
+          status: "draft", // Always start as draft
+        },
+        apiKey,
+      );
 
       // Assign audience IDs (brand stories) if provided
       if (input.audienceIds?.length) {


### PR DESCRIPTION
## Summary

Fixes the BigQuery access denied errors by eliminating dependencies on external tables and adding direct `customer_id` columns for multi-tenant security filtering.

### Changes Made

- **Added `customer_id` columns** to `campaigns` and `creatives` BigQuery tables
- **Updated BigQuery service methods** to use direct customer_id filtering instead of JOINs with external `swift-catfish-337215.postgres_datastream.public_agent` table
- **Removed all external table JOINs** that were causing access denied errors
- **Updated method signatures** to pass API tokens for proper customer ID resolution
- **Applied database migrations** to add columns and populate existing data

### Methods Updated

**Campaign operations:**
- `createCampaign` - includes customer_id when inserting new campaigns
- `listCampaigns` - uses direct customer_id filter instead of external JOIN
- `getCampaign` - uses direct customer_id filter instead of external JOIN
- `deleteCampaign` - uses direct customer_id filter instead of subquery
- `updateCampaign` - uses direct customer_id filter instead of subquery

**Creative operations:**
- `createCreative` - includes customer_id when inserting new creatives
- `getCreative` - uses direct customer_id filter instead of external JOIN
- `listCreatives` - uses direct customer_id filter instead of external JOIN

### Results

✅ `campaign/list` now works without "Access Denied: Table swift-catfish-337215:postgres_datastream.public_agent" errors
✅ All campaign and creative operations maintain proper multi-tenant security
✅ Authentication service continues to function as-is
✅ No more dependency on external tables that may not be accessible

### Test Plan

- [x] Verified `campaign/list` works without API key access errors
- [x] Tested campaign filtering by brand agent ID 
- [x] Confirmed creative listing operations work
- [x] Validated that existing data was properly migrated
- [x] All pre-commit hooks and CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)